### PR TITLE
feat: add hybrid human/agent implementation workflow (impl-brief + impl-assist)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ This file adds only Claude-specific notes.
 ## Scope reminder
 
 This repo IS the workflow bundle. Do not run `/spec-init`, `/phase-init`, `/phase-gate`,
-`/spec-sync`, or `/context-update` against this repo's `docs/` — those skills are shipped to
-integrated projects. The only skill that runs from here is `/workflow-init <target-path>`, and the
-target must be **outside** this repo.
+`/spec-sync`, `/context-update`, `/impl-brief`, or `/impl-assist` against this repo's `docs/` —
+those skills are shipped to integrated projects. The only skill that runs from here is
+`/workflow-init <target-path>`, and the target must be **outside** this repo.
 
 ## Skills shipped from this repo
 
@@ -21,6 +21,8 @@ target must be **outside** this repo.
 | `/phase-gate` (in integrated projects) | [`docs/playbooks/phase-gate.md`](docs/playbooks/phase-gate.md) |
 | `/spec-sync` (in integrated projects) | [`docs/playbooks/spec-sync.md`](docs/playbooks/spec-sync.md) |
 | `/context-update` (in integrated projects) | [`docs/playbooks/context-update.md`](docs/playbooks/context-update.md) |
+| `/impl-brief` (in integrated projects) | [`docs/playbooks/impl-brief.md`](docs/playbooks/impl-brief.md) |
+| `/impl-assist` (in integrated projects) | [`docs/playbooks/impl-assist.md`](docs/playbooks/impl-assist.md) |
 
 Wrappers under `.claude/skills/` and `project-files/.claude/skills/` are intentionally thin —
 they just point at the playbooks above. To change workflow behavior, edit the playbook, never the

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -6,10 +6,10 @@ There are two audiences:
 
 1. **The `sdd-workflow` repo itself.** Only one playbook is reachable from here:
    [workflow-init.md](./workflow-init.md). It describes how an agent integrates this workflow into
-   a target project. The other five playbooks are shipped to the target project by `workflow-init`
+   a target project. The other playbooks are shipped to the target project by `workflow-init`
    and become reachable there.
 2. **An integrated project.** After `/workflow-init` has run, the target project gets a copy of all
-   six playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
+   eight playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
    and `plugins/sdd-workflow/`. Those wrappers do not contain workflow logic — they point here.
 
 To change a workflow, edit only the playbook file. The wrappers stay one-line stubs.
@@ -18,10 +18,12 @@ To change a workflow, edit only the playbook file. The wrappers stay one-line st
 
 - [workflow-init.md](./workflow-init.md) — integrate the SDD workflow into a target project (new or existing)
 - [spec-init.md](./spec-init.md) — draft or refresh `docs/SPEC.md` from a product brief
-- [phase-init.md](./phase-init.md) — scaffold a new `docs/PHASE_XX.md`
+- [phase-init.md](./phase-init.md) — scaffold a new `docs/PHASE_XX.md` + `docs/PHASE_XX_NOTES.md`
 - [phase-gate.md](./phase-gate.md) — validate a phase before commit (commands live in `docs/STACK.md`)
 - [spec-sync.md](./spec-sync.md) — propagate a `docs/SPEC.md` change
 - [context-update.md](./context-update.md) — finalize a completed phase
+- [impl-brief.md](./impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
+- [impl-assist.md](./impl-assist.md) — implement uncompleted phase tasks (optional)
 
 ## Stack-specific commands
 

--- a/docs/playbooks/impl-assist.md
+++ b/docs/playbooks/impl-assist.md
@@ -1,0 +1,124 @@
+# impl-assist — Canonical Playbook
+
+Implement one or more uncompleted tasks from a phase, verify completion by reading actual code
+(not just checkbox state), and update the Scope checklist in `docs/PHASE_XX.md`.
+
+This document is the single source of truth for the `impl-assist` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/impl-assist/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/impl-assist/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/impl-assist [XX]                 — full phase (all unchecked tasks)
+/impl-assist [XX] [ID]            — single task, e.g. B3
+/impl-assist [XX] [group]         — group, e.g. backend | frontend | infra | data
+/impl-assist [XX] [ID] --force    — implement even if checkbox is checked
+```
+
+- `XX` — zero-padded phase number
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to prefix: `backend`→`B*`, `frontend`→`F*`, `infra`→`I*`, `data`→`D*`
+- `--force` — implement even if the checkbox is checked (useful for re-implementation)
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts, `Depends on:` fields
+- `docs/PHASE_XX_NOTES.md` — Implementation Plan and Decisions & Notes for each task
+- `docs/CONTEXT.md` — current code state
+- `docs/STACK.md` — stack conventions, test commands, file layout
+- `docs/KNOWN_GOTCHAS.md` — project pitfalls
+- Relevant source files — to verify current implementation state
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number, ask: "Which phase? e.g. /impl-assist 01 B3"
+- Normalize phase number to two digits.
+- Resolve target task list from the input scope argument.
+
+### 2. Dependency check
+
+For each target task: read its `Depends on:` field from `docs/PHASE_XX.md`.
+- If any declared dependency task is **unchecked** in the Scope checklist AND not in the current
+  target list: report the blocking dependency and skip the dependent task.
+  ```
+  ⚠ B3 blocked — depends on B2 (unchecked). Run /impl-assist [XX] B2 first, or include B2 in scope.
+  ```
+- Do not add dependency tasks to the implementation queue automatically — make it explicit.
+
+### 3. Completion verification
+
+For each target task (in dependency order — dependencies first):
+
+**Do not trust the checkbox alone.** Verify actual code state:
+- Identify the files declared or implied by the Implementation Plan in `docs/PHASE_XX_NOTES.md`.
+- If no Implementation Plan exists for this task, generate one inline using the same logic as
+  `impl-brief` (read contracts, context, existing code) before proceeding.
+- Read each relevant file. Check whether the contracts from `docs/PHASE_XX.md` are concretely
+  implemented: required functions/routes/components exist, schemas match, tests exist.
+- Determine status:
+  - **Implemented**: contracts satisfied in code → skip (unless `--force`).
+  - **Skeleton/partial**: file exists but implementation is incomplete → implement remaining parts.
+  - **Not started**: file absent or contract not implemented → implement in full.
+
+### 4. Read Decisions & Notes
+
+Before writing any code for a task: read its `### Decisions & Notes` section in
+`docs/PHASE_XX_NOTES.md`. If the human has documented decisions (alternative approaches chosen,
+constraints, deviations from the plan), honour those decisions over the Implementation Plan.
+
+### 5. Implement
+
+For each task requiring implementation (skeleton or not-started status):
+- Follow the Implementation Plan from `docs/PHASE_XX_NOTES.md` (adjusted for Decisions & Notes).
+- Match the project's naming conventions, import style, and patterns observed in existing code.
+- Write tests alongside implementation code — do not treat them as a separate task.
+- After implementing each individual task: check off its checkbox in `docs/PHASE_XX.md`
+  (`- [ ]` → `- [x]`).
+- Commit atomically per task following the Atomic Commits rule in `AGENTS.md`:
+  `feat|fix|chore(phase-[XX]): [task ID] [short description]`
+
+### 6. Post-implementation check
+
+After all target tasks are implemented:
+- Re-read the implemented files and confirm the contracts from `docs/PHASE_XX.md` are satisfied.
+- If any contract is unsatisfied, fix it before reporting success.
+
+### 7. Report
+
+```
+## impl-assist complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Implemented:
+  [ID] — [task name]: ✅ committed as [commit hash]
+
+Skipped (already implemented):
+  [ID] — [task name]
+
+Blocked (dependency unchecked):
+  [ID] — [task name]: depends on [dep ID]
+
+Next: run `/phase-gate [XX]` to validate the full phase.
+```
+
+## Rules
+
+- Never write to `### Decisions & Notes` sections in `docs/PHASE_XX_NOTES.md`.
+- Verify by code, not by checkbox. A checked box is a hint, not proof.
+- Honour `### Decisions & Notes` over `### Implementation Plan` when they conflict.
+- Do not implement tasks whose declared dependencies are unchecked (unless `--force`).
+- Do not run gate — that is a separate step.
+- Follow all rules in `AGENTS.md` (no hardcoded secrets, no push to main, atomic commits).
+
+## Done when
+
+- All targeted tasks are either implemented (and committed) or explicitly reported as skipped/blocked.
+- All implemented tasks have their checkboxes checked in `docs/PHASE_XX.md`.
+- The report clearly lists every task outcome.

--- a/docs/playbooks/impl-brief.md
+++ b/docs/playbooks/impl-brief.md
@@ -1,0 +1,120 @@
+# impl-brief — Canonical Playbook
+
+Generate a concrete implementation plan for one or more tasks in a phase and write it to the
+`### Implementation Plan` section(s) of `docs/PHASE_XX_NOTES.md`.
+
+This document is the single source of truth for the `impl-brief` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/impl-brief/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/impl-brief/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/impl-brief [XX]                 — full phase (all tasks)
+/impl-brief [XX] [ID]            — single task, e.g. B3
+/impl-brief [XX] [group]         — group, e.g. backend | frontend | infra | data
+/impl-brief [XX] [ID] --force    — overwrite existing Implementation Plan
+/impl-brief [XX] [group] --force — overwrite group
+```
+
+- `XX` — zero-padded phase number (e.g. `01`)
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to all tasks with the matching prefix: `backend`→`B*`, `frontend`→`F*`,
+  `infra`→`I*`, `data`→`D*`
+- `--force` — overwrite `### Implementation Plan` even if it already has content
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts (data model, endpoints, types, env vars)
+- `docs/PHASE_XX_NOTES.md` — existing content; used to detect which sections to skip
+- `docs/CONTEXT.md` — current code state (active models, endpoints, db schema)
+- `docs/STACK.md` — stack conventions, file layout, package managers
+- `docs/KNOWN_GOTCHAS.md` — project pitfalls relevant to the target tasks
+- Relevant existing source files — to match naming conventions, import styles, and patterns
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number, ask: "Which phase? e.g. /impl-brief 01 B3"
+- Normalize phase number to two digits.
+- If `docs/PHASE_XX_NOTES.md` does not exist: create it from `docs/PHASE_NOTES_TEMPLATE.md`
+  with stubs for all tasks in `docs/PHASE_XX.md` § Scope, then proceed.
+- Resolve target task list from the input scope argument (see Input section above).
+
+### 2. Read context
+
+For each target task:
+- Extract the task description and `Depends on:` field from `docs/PHASE_XX.md` § Scope.
+- Extract relevant contracts from `docs/PHASE_XX.md` (schemas, endpoints, types, env vars) that
+  apply to this task.
+- Read `docs/CONTEXT.md` for active models, endpoints, and db schema head.
+- Read relevant source files to infer: directory layout, naming conventions, import patterns,
+  existing base classes or utility functions to reuse.
+- Scan `docs/KNOWN_GOTCHAS.md` for entries whose symptoms match this task's domain.
+
+### 3. Skip check
+
+For each target task: if `### Implementation Plan` already has non-empty content AND `--force` was
+not passed — mark as SKIPPED and do not overwrite. Log the skip in the report.
+
+### 4. Generate Implementation Plan
+
+For each non-skipped target task, write a concrete plan to `### Implementation Plan`. The plan must
+include:
+
+- **Done when:** one or two concrete, testable sentences stating what must be true for this task
+  to be considered complete. Derive from the task's contracts in PHASE_XX.md and test conventions
+  in STACK.md. Examples: specific endpoint response codes and shapes, a named test that passes,
+  a DB column that exists with its type.
+- **Follows pattern:** path to an existing file (and optionally function/component) whose structure
+  should be copied verbatim. Write "—" if no analogous implementation exists yet. Derive from the
+  source file scan in step 2.
+- **Files**: exact paths (relative to repo root) to create or modify
+- **Code structure**: function/class/component signatures in the project's language, matching
+  existing naming conventions from source files
+- **Migration SQL** (if the task involves a DB change): full `CREATE TABLE` / `ALTER TABLE`
+  statement, matching the migration tool conventions from `docs/STACK.md`
+- **Step-by-step order**: numbered steps, honouring the `Depends on:` chain within the task
+- **Gotcha callouts**: inline note if `KNOWN_GOTCHAS.md` has a relevant entry
+
+Do **not** write to `### Decisions & Notes`. That section belongs to the human.
+
+### 5. Write to PHASE_XX_NOTES.md
+
+Using surgical edits (not full-file rewrite): replace the empty `### Implementation Plan` content
+(or overwrite if `--force`) for each target task. Preserve all other file content unchanged,
+including any existing `### Decisions & Notes` entries.
+
+### 6. Report
+
+```
+## impl-brief complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Written:
+  [ID] — [task name]: docs/PHASE_[XX]_NOTES.md § Implementation Plan ✅
+
+Skipped (already has content — use --force to overwrite):
+  [ID] — [task name]
+
+Next: implement the tasks or run `/impl-assist [XX] [ID]` to have the agent implement.
+```
+
+## Rules
+
+- Never write to `### Decisions & Notes` sections.
+- Never modify `docs/PHASE_XX.md`, `docs/SPEC.md`, or `docs/CONTEXT.md`.
+- Do not commit.
+- If a task's `Depends on:` references another task with an empty Implementation Plan, generate
+  the dependency's plan first (in dependency order), then the requested task.
+
+## Done when
+
+- `docs/PHASE_XX_NOTES.md` exists.
+- Each targeted `### Implementation Plan` section has concrete, actionable content.
+- The report lists all written and skipped tasks.

--- a/docs/playbooks/phase-init.md
+++ b/docs/playbooks/phase-init.md
@@ -15,6 +15,7 @@ thin stubs — every workflow detail lives in this file.
 ## Required reads
 
 - `docs/PHASE_TEMPLATE.md`
+- `docs/PHASE_NOTES_TEMPLATE.md`
 - `docs/CONTEXT.md` — note current `_meta.version` and `phase_completed`
 - `docs/STATE.md` — find the previous phase status
 - `docs/SPEC.md` — read all sections, especially §3 (data model), §4 (API/backend), §5 (frontend), §6 (infra), §8 (phases plan)
@@ -51,7 +52,16 @@ If skipped: omit the `## Design References` section from the phase doc entirely.
 
 ### 4. Extract scope and contracts from `docs/SPEC.md`
 
-**Scope** (from §8): phase title and all scope items.
+**Scope** (from §8): phase title and all scope items. After extracting items, assign task IDs:
+
+1. Group items into: Backend, Frontend, Infra, Data, or ungrouped (Other).
+2. Assign IDs sequentially within each group: `B1`, `B2`… for Backend; `F1`, `F2`… for Frontend;
+   `I1`… for Infra; `D1`… for Data; `T1`… for ungrouped items.
+3. Detect logical dependencies within the phase: migrations before models, models before routes,
+   routes before tests. Express as `_Depends on:_ B1` or `—` for none.
+4. Format each item: `- [ ] \`B2\` [description] — _Depends on:_ \`B1\``
+
+IDs are stable once assigned. Never renumber. If a task is removed later, mark it `~~BN~~ (removed)`.
 
 **New DB tables / columns** (from §3): tables first introduced in this phase, matched against the scope description. Paste verbatim blocks. Do not include tables that already existed.
 
@@ -76,28 +86,54 @@ Copy `docs/PHASE_TEMPLATE.md` and substitute placeholders:
 | `v0.[XX].0` | Tag |
 | `PHASE_[XX-1]` | Previous phase |
 | `[VERSION]` | Current `_meta.version` from `docs/CONTEXT.md` |
-| Scope checkboxes | Items from §8 as `- [ ] [item]` |
+| Scope checkboxes | Items from §8 with task IDs assigned in step 4: `- [ ] \`B1\` [item] — _Depends on:_ —` |
 | Files | Explicit list from step 3 |
 | Contracts | Extracted sections from step 3 |
 | Atomic Commit Message | `feat(phase-[XX]): [phase title lowercased] — [2–4 key deliverables]`, under 72 chars |
 
 Use `[TODO: verify]` only for details genuinely absent from SPEC.md (e.g. a smoke-test response body example). Do not invent data.
 
-### 6. Append the phase row to `docs/STATE.md`
+### 6. Create `docs/PHASE_XX_NOTES.md`
+
+Copy `docs/PHASE_NOTES_TEMPLATE.md` and generate one task block per Scope item assigned in step 4:
+
+```markdown
+## [ID] — [task description]
+**Depends on:** [IDs or —]
+
+### Implementation Plan
+<!-- Run `/impl-brief [XX] [ID]` to generate. -->
+
+### Decisions & Notes
+<!-- Human writes here. Never overwritten by agent. -->
+```
+
+Save as `docs/PHASE_[XX]_NOTES.md`. Update the `_Generated:` date. Leave all sections empty —
+this is a stub. The Implementation Plans are populated later by `/impl-brief`.
+
+### 7. Append the phase row to `docs/STATE.md`
 
 Add to the Phase Status table:
 
 ```
-| PHASE_[XX] | ⏳ pending | v0.[XX].0 | ⬜ | - | [Phase Title] |
+| PHASE_[XX] | ⏳ pending | v0.[XX].0 | ⬜ | — | [Phase Title] |
 ```
 
-### 7. Report
+### 8. Report
 
 ```
 ## phase-init complete
 
 Created: docs/PHASE_[XX].md
+Created: docs/PHASE_[XX]_NOTES.md (stub — run /impl-brief [XX] to populate Implementation Plans)
 STATE.md: PHASE_[XX] row added (⏳ pending)
+
+Scope tasks assigned:
+- Backend:  [B1, B2, … or "none"]
+- Frontend: [F1, F2, … or "none"]
+- Infra:    [I1, … or "none"]
+- Data:     [D1, … or "none"]
+- Other:    [T1, … or "none"]
 
 Contracts filled from SPEC.md:
 - DB tables: [list or "none"]
@@ -107,7 +143,8 @@ Contracts filled from SPEC.md:
 - Env vars: [count]
 - Files: [count]
 
-Before handing to the implementing agent, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
+Before implementation, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
+Run /impl-brief [XX] (or /impl-brief [XX] [ID]) to generate concrete Implementation Plans.
 
 CONTEXT.md version at time of init: [version]
 ```
@@ -120,5 +157,6 @@ CONTEXT.md version at time of init: [version]
 
 ## Done when
 
-- `docs/PHASE_XX.md` exists and is filled from `docs/SPEC.md`.
+- `docs/PHASE_XX.md` exists and is filled from `docs/SPEC.md` with task IDs in Scope.
+- `docs/PHASE_XX_NOTES.md` exists as a stub with one block per Scope task.
 - `docs/STATE.md` contains the new pending row.

--- a/docs/playbooks/workflow-init.md
+++ b/docs/playbooks/workflow-init.md
@@ -90,6 +90,7 @@ For conflicts, default policy:
   overwrite. Leave the existing file. Report a warning.
 - For `docs/playbooks/<name>.md`: overwrite (these are versioned with the workflow).
 - For `.claude/skills/<name>/SKILL.md` and `plugins/sdd-workflow/...`: overwrite (wrappers).
+- For `docs/templates/PHASE_NOTES_TEMPLATE.md` → `docs/PHASE_NOTES_TEMPLATE.md`: do **not** overwrite.
 - For `scripts/*` and `.mcp.json`: skip if already present.
 
 Show the user a planned action list **before** writing anything. Wait for `proceed` (or accept the
@@ -111,16 +112,18 @@ Files to copy from `project-files/` to the target root, preserving structure:
 - `AGENTS.md` → `AGENTS.md`
 - `CLAUDE.md` → `CLAUDE.md`
 - `.mcp.json` → `.mcp.json`
-- `.claude/skills/<5 skills>/SKILL.md` → `.claude/skills/<5 skills>/SKILL.md`
+- `.claude/skills/<7 skills>/SKILL.md` → `.claude/skills/<7 skills>/SKILL.md`
+  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist)
 - `plugins/sdd-workflow/` → `plugins/sdd-workflow/` (commands, skills, hooks.json, .mcp.json,
   .codex-plugin/, scripts/, README.md)
-- `docs/playbooks/<6 playbooks>.md` → `docs/playbooks/<6 playbooks>.md` (includes `workflow-init.md`
-  for future-self reference)
+- `docs/playbooks/<8 playbooks>.md` → `docs/playbooks/<8 playbooks>.md` (includes `workflow-init.md`
+  for future-self reference, plus `impl-brief.md` and `impl-assist.md`)
 - `docs/templates/SPEC.md` → `docs/SPEC.md` (only if missing)
 - `docs/templates/STATE.md` → `docs/STATE.md` (only if missing)
 - `docs/templates/CHANGELOG.md` → `docs/CHANGELOG.md` (only if missing)
 - `docs/templates/CONTEXT.md` → `docs/CONTEXT.md` (only if missing)
 - `docs/templates/PHASE_TEMPLATE.md` → `docs/PHASE_TEMPLATE.md` (only if missing)
+- `docs/templates/PHASE_NOTES_TEMPLATE.md` → `docs/PHASE_NOTES_TEMPLATE.md` (only if missing)
 - `docs/templates/STACK.md` → `docs/STACK.md` (only if missing — if existing, leave it and tell the
   user where to merge gate commands)
 - `docs/templates/KNOWN_GOTCHAS.md` → `docs/KNOWN_GOTCHAS.md` (only if missing)
@@ -192,9 +195,9 @@ Produce a short report with:
 
 ## Done when
 
-- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<5>`, `plugins/sdd-workflow/`,
-  `docs/playbooks/<6>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
-  DECISIONS,PHASE_TEMPLATE}.md`.
+- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<7>`, `plugins/sdd-workflow/`,
+  `docs/playbooks/<8>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
+  DECISIONS,PHASE_TEMPLATE,PHASE_NOTES_TEMPLATE}.md`.
 - `docs/STACK.md` either has user-supplied gate commands or is flagged for the user to fill in.
 - The user has the exact "next steps" list and knows the cloned `sdd-workflow` checkout can be
   deleted.

--- a/project-files/.claude/skills/impl-assist/SKILL.md
+++ b/project-files/.claude/skills/impl-assist/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: impl-assist
+description: Implement uncompleted phase tasks. Verifies completion by reading actual code (not just checkbox state), respects Decisions & Notes, checks dependencies, and updates the Scope checklist when done.
+allowed-tools: Read, Write, Edit, Glob, Bash
+argument-hint: "[phase] [task-id | group | --force]"
+---
+
+You are running the SDD `impl-assist` workflow.
+
+**Arguments**: $ARGUMENTS
+
+Execute the canonical playbook in [docs/playbooks/impl-assist.md](../../../docs/playbooks/impl-assist.md). That file is the source of truth for dependency checks, completion verification, and the final report format.
+
+If `$ARGUMENTS` is empty, ask: "Which phase and task? e.g. /impl-assist 01 B3 or /impl-assist 01 backend"

--- a/project-files/.claude/skills/impl-brief/SKILL.md
+++ b/project-files/.claude/skills/impl-brief/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: impl-brief
+description: Generate a concrete implementation plan for phase tasks. Reads contracts from PHASE_XX.md and existing code patterns, then writes to the Implementation Plan section(s) of PHASE_XX_NOTES.md. Never overwrites Decisions & Notes.
+allowed-tools: Read, Write, Edit, Glob, Bash
+argument-hint: "[phase] [task-id | group | --force]"
+---
+
+You are running the SDD `impl-brief` workflow.
+
+**Arguments**: $ARGUMENTS
+
+Execute the canonical playbook in [docs/playbooks/impl-brief.md](../../../docs/playbooks/impl-brief.md). That file is the source of truth for scope resolution, overwrite rules, and the final report format.
+
+If `$ARGUMENTS` is empty, ask: "Which phase and task? e.g. /impl-brief 01 B3 or /impl-brief 01 backend"

--- a/project-files/docs/playbooks/README.md
+++ b/project-files/docs/playbooks/README.md
@@ -6,10 +6,10 @@ There are two audiences:
 
 1. **The `sdd-workflow` repo itself.** Only one playbook is reachable from here:
    [workflow-init.md](./workflow-init.md). It describes how an agent integrates this workflow into
-   a target project. The other five playbooks are shipped to the target project by `workflow-init`
+   a target project. The other playbooks are shipped to the target project by `workflow-init`
    and become reachable there.
 2. **An integrated project.** After `/workflow-init` has run, the target project gets a copy of all
-   six playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
+   eight playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
    and `plugins/sdd-workflow/`. Those wrappers do not contain workflow logic — they point here.
 
 To change a workflow, edit only the playbook file. The wrappers stay one-line stubs.
@@ -18,10 +18,12 @@ To change a workflow, edit only the playbook file. The wrappers stay one-line st
 
 - [workflow-init.md](./workflow-init.md) — integrate the SDD workflow into a target project (new or existing)
 - [spec-init.md](./spec-init.md) — draft or refresh `docs/SPEC.md` from a product brief
-- [phase-init.md](./phase-init.md) — scaffold a new `docs/PHASE_XX.md`
+- [phase-init.md](./phase-init.md) — scaffold a new `docs/PHASE_XX.md` + `docs/PHASE_XX_NOTES.md`
 - [phase-gate.md](./phase-gate.md) — validate a phase before commit (commands live in `docs/STACK.md`)
 - [spec-sync.md](./spec-sync.md) — propagate a `docs/SPEC.md` change
 - [context-update.md](./context-update.md) — finalize a completed phase
+- [impl-brief.md](./impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
+- [impl-assist.md](./impl-assist.md) — implement uncompleted phase tasks (optional)
 
 ## Stack-specific commands
 

--- a/project-files/docs/playbooks/impl-assist.md
+++ b/project-files/docs/playbooks/impl-assist.md
@@ -1,0 +1,124 @@
+# impl-assist — Canonical Playbook
+
+Implement one or more uncompleted tasks from a phase, verify completion by reading actual code
+(not just checkbox state), and update the Scope checklist in `docs/PHASE_XX.md`.
+
+This document is the single source of truth for the `impl-assist` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/impl-assist/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/impl-assist/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/impl-assist [XX]                 — full phase (all unchecked tasks)
+/impl-assist [XX] [ID]            — single task, e.g. B3
+/impl-assist [XX] [group]         — group, e.g. backend | frontend | infra | data
+/impl-assist [XX] [ID] --force    — implement even if checkbox is checked
+```
+
+- `XX` — zero-padded phase number
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to prefix: `backend`→`B*`, `frontend`→`F*`, `infra`→`I*`, `data`→`D*`
+- `--force` — implement even if the checkbox is checked (useful for re-implementation)
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts, `Depends on:` fields
+- `docs/PHASE_XX_NOTES.md` — Implementation Plan and Decisions & Notes for each task
+- `docs/CONTEXT.md` — current code state
+- `docs/STACK.md` — stack conventions, test commands, file layout
+- `docs/KNOWN_GOTCHAS.md` — project pitfalls
+- Relevant source files — to verify current implementation state
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number, ask: "Which phase? e.g. /impl-assist 01 B3"
+- Normalize phase number to two digits.
+- Resolve target task list from the input scope argument.
+
+### 2. Dependency check
+
+For each target task: read its `Depends on:` field from `docs/PHASE_XX.md`.
+- If any declared dependency task is **unchecked** in the Scope checklist AND not in the current
+  target list: report the blocking dependency and skip the dependent task.
+  ```
+  ⚠ B3 blocked — depends on B2 (unchecked). Run /impl-assist [XX] B2 first, or include B2 in scope.
+  ```
+- Do not add dependency tasks to the implementation queue automatically — make it explicit.
+
+### 3. Completion verification
+
+For each target task (in dependency order — dependencies first):
+
+**Do not trust the checkbox alone.** Verify actual code state:
+- Identify the files declared or implied by the Implementation Plan in `docs/PHASE_XX_NOTES.md`.
+- If no Implementation Plan exists for this task, generate one inline using the same logic as
+  `impl-brief` (read contracts, context, existing code) before proceeding.
+- Read each relevant file. Check whether the contracts from `docs/PHASE_XX.md` are concretely
+  implemented: required functions/routes/components exist, schemas match, tests exist.
+- Determine status:
+  - **Implemented**: contracts satisfied in code → skip (unless `--force`).
+  - **Skeleton/partial**: file exists but implementation is incomplete → implement remaining parts.
+  - **Not started**: file absent or contract not implemented → implement in full.
+
+### 4. Read Decisions & Notes
+
+Before writing any code for a task: read its `### Decisions & Notes` section in
+`docs/PHASE_XX_NOTES.md`. If the human has documented decisions (alternative approaches chosen,
+constraints, deviations from the plan), honour those decisions over the Implementation Plan.
+
+### 5. Implement
+
+For each task requiring implementation (skeleton or not-started status):
+- Follow the Implementation Plan from `docs/PHASE_XX_NOTES.md` (adjusted for Decisions & Notes).
+- Match the project's naming conventions, import style, and patterns observed in existing code.
+- Write tests alongside implementation code — do not treat them as a separate task.
+- After implementing each individual task: check off its checkbox in `docs/PHASE_XX.md`
+  (`- [ ]` → `- [x]`).
+- Commit atomically per task following the Atomic Commits rule in `AGENTS.md`:
+  `feat|fix|chore(phase-[XX]): [task ID] [short description]`
+
+### 6. Post-implementation check
+
+After all target tasks are implemented:
+- Re-read the implemented files and confirm the contracts from `docs/PHASE_XX.md` are satisfied.
+- If any contract is unsatisfied, fix it before reporting success.
+
+### 7. Report
+
+```
+## impl-assist complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Implemented:
+  [ID] — [task name]: ✅ committed as [commit hash]
+
+Skipped (already implemented):
+  [ID] — [task name]
+
+Blocked (dependency unchecked):
+  [ID] — [task name]: depends on [dep ID]
+
+Next: run `/phase-gate [XX]` to validate the full phase.
+```
+
+## Rules
+
+- Never write to `### Decisions & Notes` sections in `docs/PHASE_XX_NOTES.md`.
+- Verify by code, not by checkbox. A checked box is a hint, not proof.
+- Honour `### Decisions & Notes` over `### Implementation Plan` when they conflict.
+- Do not implement tasks whose declared dependencies are unchecked (unless `--force`).
+- Do not run gate — that is a separate step.
+- Follow all rules in `AGENTS.md` (no hardcoded secrets, no push to main, atomic commits).
+
+## Done when
+
+- All targeted tasks are either implemented (and committed) or explicitly reported as skipped/blocked.
+- All implemented tasks have their checkboxes checked in `docs/PHASE_XX.md`.
+- The report clearly lists every task outcome.

--- a/project-files/docs/playbooks/impl-brief.md
+++ b/project-files/docs/playbooks/impl-brief.md
@@ -1,0 +1,120 @@
+# impl-brief — Canonical Playbook
+
+Generate a concrete implementation plan for one or more tasks in a phase and write it to the
+`### Implementation Plan` section(s) of `docs/PHASE_XX_NOTES.md`.
+
+This document is the single source of truth for the `impl-brief` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/impl-brief/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/impl-brief/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/impl-brief [XX]                 — full phase (all tasks)
+/impl-brief [XX] [ID]            — single task, e.g. B3
+/impl-brief [XX] [group]         — group, e.g. backend | frontend | infra | data
+/impl-brief [XX] [ID] --force    — overwrite existing Implementation Plan
+/impl-brief [XX] [group] --force — overwrite group
+```
+
+- `XX` — zero-padded phase number (e.g. `01`)
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to all tasks with the matching prefix: `backend`→`B*`, `frontend`→`F*`,
+  `infra`→`I*`, `data`→`D*`
+- `--force` — overwrite `### Implementation Plan` even if it already has content
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts (data model, endpoints, types, env vars)
+- `docs/PHASE_XX_NOTES.md` — existing content; used to detect which sections to skip
+- `docs/CONTEXT.md` — current code state (active models, endpoints, db schema)
+- `docs/STACK.md` — stack conventions, file layout, package managers
+- `docs/KNOWN_GOTCHAS.md` — project pitfalls relevant to the target tasks
+- Relevant existing source files — to match naming conventions, import styles, and patterns
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number, ask: "Which phase? e.g. /impl-brief 01 B3"
+- Normalize phase number to two digits.
+- If `docs/PHASE_XX_NOTES.md` does not exist: create it from `docs/PHASE_NOTES_TEMPLATE.md`
+  with stubs for all tasks in `docs/PHASE_XX.md` § Scope, then proceed.
+- Resolve target task list from the input scope argument (see Input section above).
+
+### 2. Read context
+
+For each target task:
+- Extract the task description and `Depends on:` field from `docs/PHASE_XX.md` § Scope.
+- Extract relevant contracts from `docs/PHASE_XX.md` (schemas, endpoints, types, env vars) that
+  apply to this task.
+- Read `docs/CONTEXT.md` for active models, endpoints, and db schema head.
+- Read relevant source files to infer: directory layout, naming conventions, import patterns,
+  existing base classes or utility functions to reuse.
+- Scan `docs/KNOWN_GOTCHAS.md` for entries whose symptoms match this task's domain.
+
+### 3. Skip check
+
+For each target task: if `### Implementation Plan` already has non-empty content AND `--force` was
+not passed — mark as SKIPPED and do not overwrite. Log the skip in the report.
+
+### 4. Generate Implementation Plan
+
+For each non-skipped target task, write a concrete plan to `### Implementation Plan`. The plan must
+include:
+
+- **Done when:** one or two concrete, testable sentences stating what must be true for this task
+  to be considered complete. Derive from the task's contracts in PHASE_XX.md and test conventions
+  in STACK.md. Examples: specific endpoint response codes and shapes, a named test that passes,
+  a DB column that exists with its type.
+- **Follows pattern:** path to an existing file (and optionally function/component) whose structure
+  should be copied verbatim. Write "—" if no analogous implementation exists yet. Derive from the
+  source file scan in step 2.
+- **Files**: exact paths (relative to repo root) to create or modify
+- **Code structure**: function/class/component signatures in the project's language, matching
+  existing naming conventions from source files
+- **Migration SQL** (if the task involves a DB change): full `CREATE TABLE` / `ALTER TABLE`
+  statement, matching the migration tool conventions from `docs/STACK.md`
+- **Step-by-step order**: numbered steps, honouring the `Depends on:` chain within the task
+- **Gotcha callouts**: inline note if `KNOWN_GOTCHAS.md` has a relevant entry
+
+Do **not** write to `### Decisions & Notes`. That section belongs to the human.
+
+### 5. Write to PHASE_XX_NOTES.md
+
+Using surgical edits (not full-file rewrite): replace the empty `### Implementation Plan` content
+(or overwrite if `--force`) for each target task. Preserve all other file content unchanged,
+including any existing `### Decisions & Notes` entries.
+
+### 6. Report
+
+```
+## impl-brief complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Written:
+  [ID] — [task name]: docs/PHASE_[XX]_NOTES.md § Implementation Plan ✅
+
+Skipped (already has content — use --force to overwrite):
+  [ID] — [task name]
+
+Next: implement the tasks or run `/impl-assist [XX] [ID]` to have the agent implement.
+```
+
+## Rules
+
+- Never write to `### Decisions & Notes` sections.
+- Never modify `docs/PHASE_XX.md`, `docs/SPEC.md`, or `docs/CONTEXT.md`.
+- Do not commit.
+- If a task's `Depends on:` references another task with an empty Implementation Plan, generate
+  the dependency's plan first (in dependency order), then the requested task.
+
+## Done when
+
+- `docs/PHASE_XX_NOTES.md` exists.
+- Each targeted `### Implementation Plan` section has concrete, actionable content.
+- The report lists all written and skipped tasks.

--- a/project-files/docs/playbooks/phase-init.md
+++ b/project-files/docs/playbooks/phase-init.md
@@ -15,6 +15,7 @@ thin stubs — every workflow detail lives in this file.
 ## Required reads
 
 - `docs/PHASE_TEMPLATE.md`
+- `docs/PHASE_NOTES_TEMPLATE.md`
 - `docs/CONTEXT.md` — note current `_meta.version` and `phase_completed`
 - `docs/STATE.md` — find the previous phase status
 - `docs/SPEC.md` — read all sections, especially §3 (data model), §4 (API/backend), §5 (frontend), §6 (infra), §8 (phases plan)
@@ -51,7 +52,16 @@ If skipped: omit the `## Design References` section from the phase doc entirely.
 
 ### 4. Extract scope and contracts from `docs/SPEC.md`
 
-**Scope** (from §8): phase title and all scope items.
+**Scope** (from §8): phase title and all scope items. After extracting items, assign task IDs:
+
+1. Group items into: Backend, Frontend, Infra, Data, or ungrouped (Other).
+2. Assign IDs sequentially within each group: `B1`, `B2`… for Backend; `F1`, `F2`… for Frontend;
+   `I1`… for Infra; `D1`… for Data; `T1`… for ungrouped items.
+3. Detect logical dependencies within the phase: migrations before models, models before routes,
+   routes before tests. Express as `_Depends on:_ B1` or `—` for none.
+4. Format each item: `- [ ] \`B2\` [description] — _Depends on:_ \`B1\``
+
+IDs are stable once assigned. Never renumber. If a task is removed later, mark it `~~BN~~ (removed)`.
 
 **New DB tables / columns** (from §3): tables first introduced in this phase, matched against the scope description. Paste verbatim blocks. Do not include tables that already existed.
 
@@ -76,28 +86,54 @@ Copy `docs/PHASE_TEMPLATE.md` and substitute placeholders:
 | `v0.[XX].0` | Tag |
 | `PHASE_[XX-1]` | Previous phase |
 | `[VERSION]` | Current `_meta.version` from `docs/CONTEXT.md` |
-| Scope checkboxes | Items from §8 as `- [ ] [item]` |
+| Scope checkboxes | Items from §8 with task IDs assigned in step 4: `- [ ] \`B1\` [item] — _Depends on:_ —` |
 | Files | Explicit list from step 3 |
 | Contracts | Extracted sections from step 3 |
 | Atomic Commit Message | `feat(phase-[XX]): [phase title lowercased] — [2–4 key deliverables]`, under 72 chars |
 
 Use `[TODO: verify]` only for details genuinely absent from SPEC.md (e.g. a smoke-test response body example). Do not invent data.
 
-### 6. Append the phase row to `docs/STATE.md`
+### 6. Create `docs/PHASE_XX_NOTES.md`
+
+Copy `docs/PHASE_NOTES_TEMPLATE.md` and generate one task block per Scope item assigned in step 4:
+
+```markdown
+## [ID] — [task description]
+**Depends on:** [IDs or —]
+
+### Implementation Plan
+<!-- Run `/impl-brief [XX] [ID]` to generate. -->
+
+### Decisions & Notes
+<!-- Human writes here. Never overwritten by agent. -->
+```
+
+Save as `docs/PHASE_[XX]_NOTES.md`. Update the `_Generated:` date. Leave all sections empty —
+this is a stub. The Implementation Plans are populated later by `/impl-brief`.
+
+### 7. Append the phase row to `docs/STATE.md`
 
 Add to the Phase Status table:
 
 ```
-| PHASE_[XX] | ⏳ pending | v0.[XX].0 | ⬜ | - | [Phase Title] |
+| PHASE_[XX] | ⏳ pending | v0.[XX].0 | ⬜ | — | [Phase Title] |
 ```
 
-### 7. Report
+### 8. Report
 
 ```
 ## phase-init complete
 
 Created: docs/PHASE_[XX].md
+Created: docs/PHASE_[XX]_NOTES.md (stub — run /impl-brief [XX] to populate Implementation Plans)
 STATE.md: PHASE_[XX] row added (⏳ pending)
+
+Scope tasks assigned:
+- Backend:  [B1, B2, … or "none"]
+- Frontend: [F1, F2, … or "none"]
+- Infra:    [I1, … or "none"]
+- Data:     [D1, … or "none"]
+- Other:    [T1, … or "none"]
 
 Contracts filled from SPEC.md:
 - DB tables: [list or "none"]
@@ -107,7 +143,8 @@ Contracts filled from SPEC.md:
 - Env vars: [count]
 - Files: [count]
 
-Before handing to the implementing agent, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
+Before implementation, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
+Run /impl-brief [XX] (or /impl-brief [XX] [ID]) to generate concrete Implementation Plans.
 
 CONTEXT.md version at time of init: [version]
 ```
@@ -120,5 +157,6 @@ CONTEXT.md version at time of init: [version]
 
 ## Done when
 
-- `docs/PHASE_XX.md` exists and is filled from `docs/SPEC.md`.
+- `docs/PHASE_XX.md` exists and is filled from `docs/SPEC.md` with task IDs in Scope.
+- `docs/PHASE_XX_NOTES.md` exists as a stub with one block per Scope task.
 - `docs/STATE.md` contains the new pending row.

--- a/project-files/docs/playbooks/workflow-init.md
+++ b/project-files/docs/playbooks/workflow-init.md
@@ -90,6 +90,7 @@ For conflicts, default policy:
   overwrite. Leave the existing file. Report a warning.
 - For `docs/playbooks/<name>.md`: overwrite (these are versioned with the workflow).
 - For `.claude/skills/<name>/SKILL.md` and `plugins/sdd-workflow/...`: overwrite (wrappers).
+- For `docs/templates/PHASE_NOTES_TEMPLATE.md` → `docs/PHASE_NOTES_TEMPLATE.md`: do **not** overwrite.
 - For `scripts/*` and `.mcp.json`: skip if already present.
 
 Show the user a planned action list **before** writing anything. Wait for `proceed` (or accept the
@@ -111,16 +112,18 @@ Files to copy from `project-files/` to the target root, preserving structure:
 - `AGENTS.md` → `AGENTS.md`
 - `CLAUDE.md` → `CLAUDE.md`
 - `.mcp.json` → `.mcp.json`
-- `.claude/skills/<5 skills>/SKILL.md` → `.claude/skills/<5 skills>/SKILL.md`
+- `.claude/skills/<7 skills>/SKILL.md` → `.claude/skills/<7 skills>/SKILL.md`
+  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist)
 - `plugins/sdd-workflow/` → `plugins/sdd-workflow/` (commands, skills, hooks.json, .mcp.json,
   .codex-plugin/, scripts/, README.md)
-- `docs/playbooks/<6 playbooks>.md` → `docs/playbooks/<6 playbooks>.md` (includes `workflow-init.md`
-  for future-self reference)
+- `docs/playbooks/<8 playbooks>.md` → `docs/playbooks/<8 playbooks>.md` (includes `workflow-init.md`
+  for future-self reference, plus `impl-brief.md` and `impl-assist.md`)
 - `docs/templates/SPEC.md` → `docs/SPEC.md` (only if missing)
 - `docs/templates/STATE.md` → `docs/STATE.md` (only if missing)
 - `docs/templates/CHANGELOG.md` → `docs/CHANGELOG.md` (only if missing)
 - `docs/templates/CONTEXT.md` → `docs/CONTEXT.md` (only if missing)
 - `docs/templates/PHASE_TEMPLATE.md` → `docs/PHASE_TEMPLATE.md` (only if missing)
+- `docs/templates/PHASE_NOTES_TEMPLATE.md` → `docs/PHASE_NOTES_TEMPLATE.md` (only if missing)
 - `docs/templates/STACK.md` → `docs/STACK.md` (only if missing — if existing, leave it and tell the
   user where to merge gate commands)
 - `docs/templates/KNOWN_GOTCHAS.md` → `docs/KNOWN_GOTCHAS.md` (only if missing)
@@ -192,9 +195,9 @@ Produce a short report with:
 
 ## Done when
 
-- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<5>`, `plugins/sdd-workflow/`,
-  `docs/playbooks/<6>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
-  DECISIONS,PHASE_TEMPLATE}.md`.
+- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<7>`, `plugins/sdd-workflow/`,
+  `docs/playbooks/<8>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
+  DECISIONS,PHASE_TEMPLATE,PHASE_NOTES_TEMPLATE}.md`.
 - `docs/STACK.md` either has user-supplied gate commands or is flagged for the user to fill in.
 - The user has the exact "next steps" list and knows the cloned `sdd-workflow` checkout can be
   deleted.

--- a/project-files/docs/templates/PHASE_NOTES_TEMPLATE.md
+++ b/project-files/docs/templates/PHASE_NOTES_TEMPLATE.md
@@ -1,0 +1,29 @@
+# PHASE [XX] — Implementation Notes
+
+<!--
+  WHAT to build → docs/PHASE_[XX].md  (contracts, scope checklist)
+  HOW it was built → this file         (plans, decisions, rationale)
+
+  Ownership rules:
+  - ### Implementation Plan  — written by agent (/impl-brief). Agent may update only this section.
+  - ### Decisions & Notes    — written by human. NEVER overwritten by agent.
+
+  Sync rule: task IDs (B1, F1, I1 …) must match the Scope checklist in PHASE_[XX].md.
+  To add stubs for tasks added manually to PHASE_[XX].md, run /impl-brief [XX] for the new ID.
+  To mark a removed task: prefix its heading with ~~, e.g. ## ~~B3~~ (removed). Do not delete.
+-->
+
+_Phase:_ `[XX]` · _Generated:_ `[DATE]`
+
+---
+
+<!-- Repeat the block below for each task ID from PHASE_[XX].md § Scope -->
+
+## [B1] — [task name]
+**Depends on:** —
+
+### Implementation Plan
+<!-- Run `/impl-brief [XX] B1` to generate. Output includes: Done when / Follows pattern / steps. -->
+
+### Decisions & Notes
+<!-- Document implementation decisions, deviations from plan, and lessons learned. -->

--- a/project-files/docs/templates/PHASE_TEMPLATE.md
+++ b/project-files/docs/templates/PHASE_TEMPLATE.md
@@ -34,10 +34,19 @@
 
 ## Scope
 
-<!-- Group tasks by area (Backend / Frontend / Infra / Data, etc.) or list flat — match what fits
-     this project. Each item is one checkbox. -->
+<!-- Group tasks by area (Backend / Frontend / Infra / Data, etc.).
+     ID scheme: B=Backend · F=Frontend · I=Infra · D=Data · T=other (ungrouped)
+     Each item: `ID` description — _Depends on:_ ID, ID or —
+     IDs are stable after assignment — never renumber. Mark removed tasks as ~~BN~~ (removed). -->
 
-- [ ] [task]
+### Backend
+- [ ] `B1` [task] — _Depends on:_ —
+
+### Frontend
+- [ ] `F1` [task] — _Depends on:_ —
+
+### Infra
+- [ ] `I1` [task] — _Depends on:_ —
 
 <!-- Test execution is governed by `## Gate Checks` below + docs/STACK.md § Gate Commands.
      Do not duplicate that list here. -->
@@ -91,6 +100,9 @@ None
 
 ## Gate Checks
 
+> **Before running gate:** confirm all Scope checkboxes are checked (or explicitly deferred in
+> Architect Review Notes). Unchecked items appear in the gate report as a warning, not a hard block.
+
 Run `/phase-gate [XX]` before committing.
 
 `/phase-gate` returns full PASS only when:
@@ -136,6 +148,8 @@ feat(phase-[XX]): [short description — what was built, not how]
 
 ## Post-Phase Checklist
 
+- [ ] All Scope checkboxes checked (or deferred in Architect Review Notes)
+- [ ] `docs/PHASE_[XX]_NOTES.md` complete — Implementation Plans filled, key decisions recorded
 - [ ] All automated gate checks green
 - [ ] All architect review notes resolved
 - [ ] `docs/CONTEXT.md` updated — run `/context-update [XX]`

--- a/project-files/docs/templates/STATE.md
+++ b/project-files/docs/templates/STATE.md
@@ -2,18 +2,20 @@
 
 > **Status legend**
 > `⏳ pending` — not started
-> `🔄 in-progress` — AI is actively implementing
+> `🔄 in-progress` — implementation in progress (human, agent, or both)
 > `✅ done` — gate checks passed, committed, merged
 > `⚠️ NEEDS_REVIEW` — spec changed, phase scope may be stale
 > `❌ blocked` — cannot proceed, see Blockers section
+>
+> **Impl By:** `👤 human` · `🤖 agent` · `🤝 hybrid` · `—` (not yet started)
 
 ---
 
 ## Phase Status
 
-| Phase    | Status     | Tag    | Gate | Expert | Notes |
-|----------|------------|--------|------|--------|-------|
-| -        | -          | -      | -    | -      | No phases yet — run `/phase-init 01` |
+| Phase    | Status     | Tag    | Gate | Impl By | Notes |
+|----------|------------|--------|------|---------|-------|
+| -        | -          | -      | -    | -       | No phases yet — run `/phase-init 01` |
 
 <!-- Add new rows here via /phase-init N -->
 

--- a/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
+++ b/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
@@ -13,7 +13,10 @@
     "spec-init",
     "phase-init",
     "spec-sync",
-    "context7"
+    "context7",
+    "impl-brief",
+    "impl-assist",
+    "human-implementation"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/project-files/plugins/sdd-workflow/README.md
+++ b/project-files/plugins/sdd-workflow/README.md
@@ -14,6 +14,8 @@ This plugin makes the project's SDD workflow visible to Codex as native:
 - `/phase-gate`
 - `/context-update`
 - `/spec-sync`
+- `/impl-brief` — generate a concrete implementation plan for phase tasks (optional)
+- `/impl-assist` — implement uncompleted phase tasks (optional)
 
 The plugin mirrors the Claude Code wrappers in `.claude/skills/`. Both runtimes point at the same canonical playbooks under `docs/playbooks/`.
 

--- a/project-files/plugins/sdd-workflow/commands/impl-assist.md
+++ b/project-files/plugins/sdd-workflow/commands/impl-assist.md
@@ -1,0 +1,11 @@
+---
+description: Implement uncompleted phase tasks, verifying completion by code inspection. Usage: /impl-assist [XX] [task-id|group] [--force]
+---
+
+# /impl-assist
+
+Execute the canonical playbook: [docs/playbooks/impl-assist.md](../../../docs/playbooks/impl-assist.md).
+
+The matching skill lives at [skills/impl-assist/SKILL.md](../skills/impl-assist/SKILL.md).
+
+If arguments are empty, ask: "Which phase and task? e.g. /impl-assist 01 B3 or /impl-assist 01 backend"

--- a/project-files/plugins/sdd-workflow/commands/impl-brief.md
+++ b/project-files/plugins/sdd-workflow/commands/impl-brief.md
@@ -1,0 +1,11 @@
+---
+description: Generate a concrete implementation plan for phase tasks and write it to PHASE_XX_NOTES.md. Usage: /impl-brief [XX] [task-id|group] [--force]
+---
+
+# /impl-brief
+
+Execute the canonical playbook: [docs/playbooks/impl-brief.md](../../../docs/playbooks/impl-brief.md).
+
+The matching skill lives at [skills/impl-brief/SKILL.md](../skills/impl-brief/SKILL.md).
+
+If arguments are empty, ask: "Which phase and task? e.g. /impl-brief 01 B3 or /impl-brief 01 backend"

--- a/project-files/plugins/sdd-workflow/skills/impl-assist/SKILL.md
+++ b/project-files/plugins/sdd-workflow/skills/impl-assist/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: impl-assist
+description: Implement uncompleted phase tasks. Verifies completion by reading actual code, respects human Decisions & Notes, checks task dependencies, implements remaining work, and updates the Scope checklist. Use when a developer wants the agent to complete or fill in tasks.
+metadata:
+  priority: 5
+  pathPatterns:
+    - 'docs/PHASE_*.md'
+    - 'docs/PHASE_*_NOTES.md'
+    - 'docs/CONTEXT.md'
+    - 'docs/STACK.md'
+  promptSignals:
+    phrases:
+      - "impl assist"
+      - "implement task"
+      - "complete task"
+      - "finish implementation"
+      - "implement remaining"
+    allOf:
+      - [impl, assist]
+      - [implement, task]
+    anyOf:
+      - "task"
+      - "phase"
+      - "unchecked"
+    noneOf: []
+    minScore: 5
+retrieval:
+  aliases:
+    - sdd impl assist
+    - implement phase task
+  intents:
+    - implement uncompleted phase tasks
+    - have agent complete remaining implementation
+  entities:
+    - PHASE_XX.md
+    - PHASE_XX_NOTES.md
+---
+
+# impl-assist
+
+Execute the canonical playbook in [docs/playbooks/impl-assist.md](../../../../docs/playbooks/impl-assist.md). That file is the source of truth for dependency checks, completion verification, and the final report format.

--- a/project-files/plugins/sdd-workflow/skills/impl-brief/SKILL.md
+++ b/project-files/plugins/sdd-workflow/skills/impl-brief/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: impl-brief
+description: Generate a concrete implementation plan for phase tasks. Reads contracts from PHASE_XX.md and existing code patterns, writes to Implementation Plan sections of PHASE_XX_NOTES.md. Use when a developer needs a detailed plan before starting implementation.
+metadata:
+  priority: 5
+  pathPatterns:
+    - 'docs/PHASE_*.md'
+    - 'docs/PHASE_*_NOTES.md'
+    - 'docs/CONTEXT.md'
+    - 'docs/STACK.md'
+  promptSignals:
+    phrases:
+      - "impl brief"
+      - "implementation brief"
+      - "implementation plan"
+      - "plan for task"
+      - "how to implement"
+    allOf:
+      - [impl, brief]
+      - [implementation, plan]
+    anyOf:
+      - "task"
+      - "phase"
+      - "implement"
+    noneOf: []
+    minScore: 5
+retrieval:
+  aliases:
+    - sdd impl brief
+    - generate implementation plan
+  intents:
+    - generate a concrete implementation plan for a phase task
+    - populate PHASE_XX_NOTES.md with implementation details
+  entities:
+    - PHASE_XX_NOTES.md
+    - PHASE_XX.md
+---
+
+# impl-brief
+
+Execute the canonical playbook in [docs/playbooks/impl-brief.md](../../../../docs/playbooks/impl-brief.md). That file is the source of truth for scope resolution, overwrite rules, and the final report format.


### PR DESCRIPTION
## Summary

Adds full support for the hybrid human/agent implementation mode — the core feature that lets developers implement tasks manually, delegate to the agent, or mix both approaches within a single phase.

### New skills

- **`/impl-brief [N] [ID|group]`** — generates a concrete Implementation Plan per task in `docs/PHASE_N_NOTES.md`. Each plan includes `Done when:` (testable acceptance criteria) and `Follows pattern:` (existing file to copy structure from) so weaker models and junior developers can implement without the orchestrating agent present.
- **`/impl-assist [N] [ID|group]`** — implements uncompleted tasks by reading actual code (not checkbox state), honours `Decisions & Notes` over `Implementation Plan` when they conflict, and commits atomically per task.

### New artifact: `PHASE_N_NOTES.md`

Per-phase dual-ownership file with one block per Scope task:
- `### Implementation Plan` — agent-written (impl-brief); skip-protected, overwrite only with `--force`
- `### Decisions & Notes` — human-written; **never read or written by any agent**

### Other changes

- `phase-init` now scaffolds `PHASE_N_NOTES.md` stub automatically
- `workflow-init` copies 7 skills (was 5) and 8 playbooks (was 6), including `PHASE_NOTES_TEMPLATE.md`
- `PHASE_TEMPLATE.md`: Scope items now have task IDs (`B1`, `F1`, `I1`, `D1`) with `Depends on:` fields
- `STATE.md` template: new `Impl By` column (`👤 human` / `🤖 agent` / `🤝 hybrid`)
- `CLAUDE.md` (repo root): impl-brief/impl-assist added to scope reminder and skills table
- READMEs and plugin metadata updated with correct skill/playbook counts

## Test plan

- [ ] `docs/playbooks/impl-brief.md` exists and contains `Done when:` / `Follows pattern:` as the first two output fields in Step 4
- [ ] `docs/playbooks/impl-assist.md` exists and verifies completion by code, not checkbox
- [ ] `project-files/.claude/skills/impl-brief/SKILL.md` and `impl-assist/SKILL.md` exist as thin wrappers
- [ ] `project-files/docs/templates/PHASE_NOTES_TEMPLATE.md` exists with the dual-section structure
- [ ] `project-files/docs/playbooks/phase-init.md` references PHASE_NOTES_TEMPLATE and generates the stub
- [ ] `project-files/docs/playbooks/workflow-init.md` copies 7 skills and 8 playbooks
- [ ] `project-files/docs/templates/PHASE_TEMPLATE.md` Scope items have task IDs
- [ ] `project-files/docs/templates/STATE.md` has `Impl By` column