### PR TITLE
feat: add /project-sync skill — idempotent GitHub Projects Kanban sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ There is no CLI, no language runtime, no test suite. All artefacts are markdown,
 
 | Concern | Authoritative file |
 |---------|--------------------|
-| Workflow procedure (any of the 6 skills) | `docs/playbooks/<name>.md` |
+| Workflow procedure (any integrated-project skill) | `docs/playbooks/<name>.md` |
 | Agent rules shipped to integrated projects | `project-files/AGENTS.md` |
 | Doc scaffolds shipped to integrated projects | `project-files/docs/templates/<name>.md` |
 | Claude Code wrapper for an integrated-project skill | `project-files/.claude/skills/<name>/SKILL.md` |
@@ -30,9 +30,10 @@ If you find logic in a wrapper, push it to the playbook and shrink the wrapper b
 
 ## Don't run derived-project skills against this repo
 
-`/spec-init`, `/phase-init`, `/phase-gate`, `/spec-sync`, `/context-update` are intended for
-integrated projects. Do not invoke them against this repo's `docs/`. The only skill that runs from
-here is `/workflow-init`, and it must be run with a target path pointing **outside** this repo.
+`/spec-init`, `/phase-init`, `/phase-gate`, `/spec-sync`, `/context-update`, `/impl-brief`,
+`/impl-assist`, `/project-sync` are intended for integrated projects. Do not invoke them against
+this repo's `docs/`. The only skill that runs from here is `/workflow-init`, and it must be run
+with a target path pointing **outside** this repo.
 
 ## Editing rules
 
@@ -90,15 +91,15 @@ skill is idempotent and only overwrites versioned files (wrappers, playbooks).
 ```
 sdd-workflow/
 ├── docs/
-│   ├── playbooks/           # CANONICAL workflow procedures (8 files)
+│   ├── playbooks/           # CANONICAL workflow procedures (9 files)
 │   └── CONTRIBUTING.md
 ├── project-files/           # Source for everything /workflow-init copies into a target project
 │   ├── AGENTS.md
 │   ├── CLAUDE.md
 │   ├── .mcp.json
-│   ├── .claude/skills/<7>/SKILL.md
+│   ├── .claude/skills/<8>/SKILL.md
 │   ├── plugins/sdd-workflow/
-│   ├── docs/playbooks/<8>.md  (mirror of docs/playbooks/)
+│   ├── docs/playbooks/<9>.md  (mirror of docs/playbooks/)
 │   └── docs/templates/<8 doc scaffolds>
 ├── .claude/skills/workflow-init/SKILL.md
 ├── plugins/sdd-workflow/      # Bootstrap-only Codex plugin (just /workflow-init)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ This file adds only Claude-specific notes.
 ## Scope reminder
 
 This repo IS the workflow bundle. Do not run `/spec-init`, `/phase-init`, `/phase-gate`,
-`/spec-sync`, `/context-update`, `/impl-brief`, or `/impl-assist` against this repo's `docs/` —
-those skills are shipped to integrated projects. The only skill that runs from here is
-`/workflow-init <target-path>`, and the target must be **outside** this repo.
+`/spec-sync`, `/context-update`, `/impl-brief`, `/impl-assist`, or `/project-sync` against this
+repo's `docs/` — those skills are shipped to integrated projects. The only skill that runs from
+here is `/workflow-init <target-path>`, and the target must be **outside** this repo.
 
 ## Skills shipped from this repo
 
@@ -23,6 +23,7 @@ those skills are shipped to integrated projects. The only skill that runs from h
 | `/context-update` (in integrated projects) | [`docs/playbooks/context-update.md`](docs/playbooks/context-update.md) |
 | `/impl-brief` (in integrated projects) | [`docs/playbooks/impl-brief.md`](docs/playbooks/impl-brief.md) |
 | `/impl-assist` (in integrated projects) | [`docs/playbooks/impl-assist.md`](docs/playbooks/impl-assist.md) |
+| `/project-sync` (in integrated projects) | [`docs/playbooks/project-sync.md`](docs/playbooks/project-sync.md) |
 
 Wrappers under `.claude/skills/` and `project-files/.claude/skills/` are intentionally thin —
 they just point at the playbooks above. To change workflow behavior, edit the playbook, never the

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -9,7 +9,7 @@ There are two audiences:
    a target project. The other playbooks are shipped to the target project by `workflow-init`
    and become reachable there.
 2. **An integrated project.** After `/workflow-init` has run, the target project gets a copy of all
-   eight playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
+   nine playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
    and `plugins/sdd-workflow/`. Those wrappers do not contain workflow logic — they point here.
 
 To change a workflow, edit only the playbook file. The wrappers stay one-line stubs.
@@ -24,6 +24,7 @@ To change a workflow, edit only the playbook file. The wrappers stay one-line st
 - [context-update.md](./context-update.md) — finalize a completed phase
 - [impl-brief.md](./impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
 - [impl-assist.md](./impl-assist.md) — implement uncompleted phase tasks (optional)
+- [project-sync.md](./project-sync.md) — sync phase tasks to GitHub Issues + GitHub Projects board (optional, GitHub-specific)
 
 ## Stack-specific commands
 

--- a/docs/playbooks/project-sync.md
+++ b/docs/playbooks/project-sync.md
@@ -146,7 +146,7 @@ phase, key, and title). Print a summary count per operation type. Stop. Do not c
 Execute queued operations in this order: `create` → `update-title` → `archive` → `close` →
 `reopen` → `set-column`.
 
-**create**
+#### create
 
 ```bash
 gh issue create \
@@ -170,7 +170,7 @@ gh project item-edit --project-id <project_id> --id <item_id> \
   --field-id <status_field_id> --single-select-option-id <target_option_id>
 ```
 
-**update-title**
+#### update-title
 
 ```bash
 gh issue edit <number> --repo <owner>/<repo> --title "[PHASE_XX][KEY] <new_title>"

--- a/docs/playbooks/project-sync.md
+++ b/docs/playbooks/project-sync.md
@@ -1,0 +1,289 @@
+# project-sync — Canonical Playbook
+
+Mirror the current state of all `docs/PHASE_XX.md` task checkboxes to GitHub Issues and a GitHub
+Projects v2 Kanban board. Idempotent — safe to run on every commit or on demand.
+
+This document is the single source of truth for the `project-sync` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/project-sync/SKILL.md` (Claude
+Code) and `plugins/sdd-workflow/{commands,skills}/project-sync/…` (Codex) point here. The wrappers
+are thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/project-sync                   — sync all phases to the GitHub board
+/project-sync [XX]              — sync single phase (two-digit, e.g. 01)
+/project-sync --dry-run         — print diff without applying any changes
+/project-sync --setup           — create GitHub Project + columns + sdd-workflow label; write config to docs/STACK.md
+/project-sync [XX] --dry-run    — dry-run for a single phase
+```
+
+- `XX` — zero-padded phase number (e.g. `01`). If omitted, all discovered `docs/PHASE_XX.md` files
+  are processed.
+- `--dry-run` — compute and print the full change queue but do not call any GitHub write API.
+- `--setup` — one-time initialisation: creates a GitHub Project, status columns, and the
+  `sdd-workflow` label; writes config to `docs/STACK.md § GitHub Project`. Must be run before the
+  first sync.
+
+## Source of truth
+
+The markdown files are always the source of truth. The GitHub board is a read-only view.
+Writing back from GitHub to markdown (e.g. issue closed on GitHub → uncheck box) is out of scope
+to avoid two-source-of-truth problems.
+
+## Required reads
+
+- `docs/PHASE_XX.md` (all, or specified) — task checkboxes and phase status
+- `docs/STATE.md` — phase status cross-check (informational only)
+- `docs/STACK.md § GitHub Project` — project number and field IDs written by `--setup`
+
+## Idempotency mechanism
+
+Every GitHub Issue created by this workflow has a hidden marker in its body:
+
+```
+<!-- sdd-sync: PHASE_01/B1 -->
+```
+
+On every run the workflow fetches all issues labelled `sdd-workflow`, parses their markers, builds
+a lookup map `(PHASE_XX/KEY) → {issue_number, state, project_item_id}`, diffs against current
+markdown state, and applies only the delta.
+
+## Task key derivation
+
+- If a scope item contains an explicit bracket ID (e.g. `**[B1]**`, `[F2]`, `[I3]`): use that as
+  the key verbatim (e.g. `B1`, `F2`).
+- Otherwise: derive a positional key `T01`, `T02`, … (sequential index within `## Scope`, 1-based,
+  zero-padded to two digits).
+- Key format in the marker: `PHASE_XX/B1` or `PHASE_XX/T01`.
+
+## Status → Project column mapping
+
+| Markdown state | Project column |
+|----------------|----------------|
+| task `[ ]`, phase `⏳ pending` | Todo |
+| task `[ ]`, phase `🔄 in-progress` | In Progress |
+| task `[ ]`, phase `⚠️ NEEDS_REVIEW` | Needs Review |
+| task `[ ]`, phase `❌ blocked` | Blocked |
+| task `[x]` (any phase status) | Done |
+
+## Full lifecycle operations
+
+| Trigger | Operation |
+|---------|-----------|
+| Task in markdown, no matching issue | Create issue + add to project + set column |
+| Task title changed (same key) | Update issue title |
+| Task `[ ]`, matching issue is closed (not `sdd-removed`) | Reopen issue + set column |
+| Task `[x]`, matching issue is open | Close issue + set column to Done |
+| Issue column differs from expected | Set column |
+| Task removed from `## Scope` | Close issue + add label `sdd-removed` |
+| No change | No-op |
+
+## Procedure
+
+### Step 1 — Prerequisite check
+
+1. If `--setup` flag is present: run the **Setup sub-procedure** (§ below), then stop.
+2. Check `gh auth status`. If not authenticated, stop:
+   > "Not authenticated. Run `gh auth login` first, then re-run `/project-sync`."
+3. Confirm remote is GitHub: `git remote get-url origin`. Extract `<owner>/<repo>`. If the remote
+   is not a github.com URL, stop with a clear message.
+4. Read `docs/STACK.md § GitHub Project`. If the section does not exist, stop:
+   > "GitHub Project not configured. Run `/project-sync --setup` first."
+5. Extract from the section: `project_number`, `status_field_id`, and option IDs for each column
+   (Todo, In Progress, Needs Review, Blocked, Done).
+
+### Step 2 — Parse markdown state
+
+1. Discover phase files: `docs/PHASE_XX.md` matching the pattern (all, or only the specified `XX`).
+2. For each phase file extract:
+   - `phase_number` — from filename (e.g. `01`)
+   - `phase_title` — from the `# PHASE XX — …` header line
+   - `phase_status` — from the `Status` row of `## Phase Metadata` table (emoji + word)
+   - `scope_items[]` — every `- [ ]` or `- [x]` line under `## Scope`:
+     - `key` — explicit `[ID]` from the line if present, else `T<NN>` (positional)
+     - `title` — text of the checkbox item, stripped of the ID prefix
+     - `checked` — `true` if `[x]` or `[X]`, `false` if `[ ]`
+
+### Step 3 — Fetch GitHub state
+
+1. Run:
+   ```bash
+   gh issue list --repo <owner>/<repo> --label sdd-workflow --state all --limit 500 \
+     --json number,title,state,body,labels
+   ```
+2. For each issue, parse `<!-- sdd-sync: PHASE_XX/KEY -->` from the body.
+3. Build lookup map: `(PHASE_XX/KEY) → {number, state}`.
+4. To get `project_item_id` for column updates: query the project's items via
+   `gh project item-list <project_number> --owner <owner> --format json --limit 500` and join on
+   issue URL.
+
+### Step 4 — Compute diff
+
+For each scope item in each phase file:
+
+1. Compute `target_column` from the status mapping table above.
+2. Look up `(PHASE_XX/KEY)` in the GitHub map:
+   - **Not found** → QUEUE `create`
+   - **Found, title differs** → QUEUE `update-title`
+   - **Found, issue closed (not `sdd-removed`) + task unchecked** → QUEUE `reopen`
+   - **Found, issue open + task checked** → QUEUE `close`
+   - **Found, open + unchecked, column differs from target** → QUEUE `set-column`
+   - **Otherwise** → no-op
+
+For each GitHub issue whose `(PHASE_XX/KEY)` is NOT present in any parsed phase file:
+
+- If issue does NOT already have label `sdd-removed` → QUEUE `archive`
+
+### Step 5 — Dry-run check
+
+If `--dry-run` was passed: print the full diff queue (all queued operations with their type,
+phase, key, and title). Print a summary count per operation type. Stop. Do not call any write API.
+
+### Step 6 — Apply changes
+
+Execute queued operations in this order: `create` → `update-title` → `archive` → `close` →
+`reopen` → `set-column`.
+
+**create**
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "[PHASE_XX][KEY] <title>" \
+  --body "<!-- sdd-sync: PHASE_XX/KEY -->
+**Phase:** PHASE_XX — <phase_title>
+**Task ID:** KEY
+
+---
+_Synced from \`docs/PHASE_XX.md\` by \`/project-sync\`_" \
+  --label sdd-workflow \
+  --label phase-XX
+```
+
+Then add to project and set column:
+
+```bash
+gh project item-add <project_number> --owner <owner> --url <issue_url>
+gh project item-edit --project-id <project_id> --id <item_id> \
+  --field-id <status_field_id> --single-select-option-id <target_option_id>
+```
+
+**update-title**
+
+```bash
+gh issue edit <number> --repo <owner>/<repo> --title "[PHASE_XX][KEY] <new_title>"
+```
+
+**archive** (task removed from scope)
+
+```bash
+gh issue edit <number> --repo <owner>/<repo> --add-label sdd-removed
+gh issue close <number> --repo <owner>/<repo>
+```
+
+**close** (task completed in markdown)
+
+```bash
+gh issue close <number> --repo <owner>/<repo>
+gh project item-edit ... --single-select-option-id <done_option_id>
+```
+
+**reopen** (task unchecked in markdown, issue was closed)
+
+```bash
+gh issue reopen <number> --repo <owner>/<repo>
+gh project item-edit ... --single-select-option-id <target_option_id>
+```
+
+**set-column** (column out of sync)
+
+```bash
+gh project item-edit --project-id <project_id> --id <item_id> \
+  --field-id <status_field_id> --single-select-option-id <target_option_id>
+```
+
+### Step 7 — Report
+
+```
+## project-sync complete
+
+Phase(s): PHASE_01, PHASE_02
+GitHub repo: <owner>/<repo>  |  Project: #<N>
+
+Created:   3 issues
+Updated:   1 issue title
+Closed:    2 issues (done)
+Reopened:  0
+Archived:  1 issue (removed from scope)
+Column:    4 issues re-placed
+No-op:     12 issues
+
+Next: view board at https://github.com/orgs/<owner>/projects/<N>
+  or run `/project-sync --dry-run` to preview future changes.
+```
+
+---
+
+## Setup sub-procedure (`--setup`)
+
+Run once per project before the first `/project-sync`.
+
+1. Check `docs/STACK.md` for an existing `## GitHub Project` section. If found, ask the user
+   to confirm overwrite before continuing.
+2. Determine `<owner>` from `git remote get-url origin`.
+3. Create the GitHub Project:
+   ```bash
+   gh project create --owner <owner> --title "<ProjectName> Board" --format json
+   ```
+   Capture `project_number` and `project_id` from output.
+4. Add a single-select Status field with five options — **Todo**, **In Progress**,
+   **Needs Review**, **Blocked**, **Done** — using the GraphQL mutation
+   `addProjectV2SingleSelectField` via `gh api graphql`.
+5. Fetch the field ID and option IDs:
+   ```bash
+   gh project field-list <project_number> --owner <owner> --format json
+   ```
+6. Create the `sdd-workflow` label if it does not exist:
+   ```bash
+   gh label create sdd-workflow --color 0075ca --repo <owner>/<repo>
+   ```
+7. Append (or replace) `## GitHub Project` section in `docs/STACK.md`:
+   ```markdown
+   ## GitHub Project
+
+   | Key | Value |
+   |-----|-------|
+   | Project number | `<N>` |
+   | Project ID | `<PVT_xxx>` |
+   | Status field ID | `<PVTSSF_xxx>` |
+   | Option: Todo | `<opt-id-todo>` |
+   | Option: In Progress | `<opt-id-inprogress>` |
+   | Option: Needs Review | `<opt-id-needsreview>` |
+   | Option: Blocked | `<opt-id-blocked>` |
+   | Option: Done | `<opt-id-done>` |
+   ```
+8. Report: "Setup complete. Run `/project-sync` to perform the first sync."
+
+---
+
+## Rules
+
+- Never modify any `docs/PHASE_XX.md` or other markdown file.
+- Never hard-delete GitHub Issues — only close + label `sdd-removed`.
+- `--dry-run` must not call any write API. All reads are allowed.
+- If any `gh` command fails (network, auth, rate limit): stop immediately. Print the failed
+  command and the error. Do not silently swallow errors or skip remaining items.
+- Cap issue body at 2 000 characters. Truncate with `…(see docs/PHASE_XX.md)` if needed.
+- If `docs/STACK.md` has no `## GitHub Project` section and `--setup` was not passed: stop with
+  the prescribed message from Step 1. Do not create the section automatically.
+- Issues labelled `sdd-removed` are never reopened by the sync, even if a task with the same
+  key reappears (treat as a new task → create a new issue).
+
+## Done when
+
+- `--setup`: `docs/STACK.md § GitHub Project` exists with all field IDs filled.
+- Sync: all scope items from targeted phase files have a corresponding open or closed GitHub Issue
+  with the correct sync marker, title, column placement, and open/closed state.
+- The report lists created, updated, closed, reopened, archived, column-changed, and no-op counts.

--- a/docs/playbooks/workflow-init.md
+++ b/docs/playbooks/workflow-init.md
@@ -112,12 +112,13 @@ Files to copy from `project-files/` to the target root, preserving structure:
 - `AGENTS.md` → `AGENTS.md`
 - `CLAUDE.md` → `CLAUDE.md`
 - `.mcp.json` → `.mcp.json`
-- `.claude/skills/<7 skills>/SKILL.md` → `.claude/skills/<7 skills>/SKILL.md`
-  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist)
+- `.claude/skills/<8 skills>/SKILL.md` → `.claude/skills/<8 skills>/SKILL.md`
+  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist,
+  project-sync)
 - `plugins/sdd-workflow/` → `plugins/sdd-workflow/` (commands, skills, hooks.json, .mcp.json,
   .codex-plugin/, scripts/, README.md)
-- `docs/playbooks/<8 playbooks>.md` → `docs/playbooks/<8 playbooks>.md` (includes `workflow-init.md`
-  for future-self reference, plus `impl-brief.md` and `impl-assist.md`)
+- `docs/playbooks/<9 playbooks>.md` → `docs/playbooks/<9 playbooks>.md` (includes `workflow-init.md`
+  for future-self reference, plus `impl-brief.md`, `impl-assist.md`, and `project-sync.md`)
 - `docs/templates/SPEC.md` → `docs/SPEC.md` (only if missing)
 - `docs/templates/STATE.md` → `docs/STATE.md` (only if missing)
 - `docs/templates/CHANGELOG.md` → `docs/CHANGELOG.md` (only if missing)
@@ -195,8 +196,8 @@ Produce a short report with:
 
 ## Done when
 
-- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<7>`, `plugins/sdd-workflow/`,
-  `docs/playbooks/<8>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
+- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<8>`, `plugins/sdd-workflow/`,
+  `docs/playbooks/<9>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
   DECISIONS,PHASE_TEMPLATE,PHASE_NOTES_TEMPLATE}.md`.
 - `docs/STACK.md` either has user-supplied gate commands or is flagged for the user to fill in.
 - The user has the exact "next steps" list and knows the cloned `sdd-workflow` checkout can be

--- a/project-files/.claude/skills/project-sync/SKILL.md
+++ b/project-files/.claude/skills/project-sync/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: project-sync
+description: Sync all phase tasks from docs/PHASE_XX.md to GitHub Issues and the GitHub Projects Kanban board. Idempotent — safe to run repeatedly. Requires gh CLI and a prior /project-sync --setup run.
+allowed-tools: Read, Bash
+argument-hint: "[XX] [--dry-run] [--setup]"
+---
+
+You are running the SDD `project-sync` workflow.
+
+**Arguments**: $ARGUMENTS
+
+Execute the canonical playbook at [docs/playbooks/project-sync.md](../../../docs/playbooks/project-sync.md). That file is the source of truth for all steps, rules, and the final report format.
+
+If $ARGUMENTS is empty, sync all phases (without --setup).

--- a/project-files/AGENTS.md
+++ b/project-files/AGENTS.md
@@ -101,10 +101,11 @@ The SDD workflows are defined in `docs/playbooks/`:
 - [`context-update`](docs/playbooks/context-update.md) — finalize a completed phase
 - [`impl-brief`](docs/playbooks/impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
 - [`impl-assist`](docs/playbooks/impl-assist.md) — implement uncompleted phase tasks (optional)
+- [`project-sync`](docs/playbooks/project-sync.md) — sync phase tasks to GitHub Issues + GitHub Projects board (optional; requires `gh` CLI and a GitHub remote)
 
 Different runtimes expose them differently:
 
-- **Claude Code**: slash commands (`/spec-init`, `/phase-init`, `/phase-gate`, `/spec-sync`, `/context-update`, `/impl-brief`, `/impl-assist`) defined under `.claude/skills/`.
+- **Claude Code**: slash commands (`/spec-init`, `/phase-init`, `/phase-gate`, `/spec-sync`, `/context-update`, `/impl-brief`, `/impl-assist`, `/project-sync`) defined under `.claude/skills/`.
 - **Codex**: slash commands defined under `plugins/sdd-workflow/`.
 - **Other runtimes**: follow the markdown procedure in `docs/playbooks/` manually.
 

--- a/project-files/CLAUDE.md
+++ b/project-files/CLAUDE.md
@@ -12,6 +12,7 @@ This file only adds Claude-specific items.
 | `/phase-init [N]` | Scaffold the next `docs/PHASE_XX.md` from SPEC | [docs/playbooks/phase-init.md](docs/playbooks/phase-init.md) |
 | `/impl-brief [N] [ID\|group]` | Before implementing: generate a concrete Implementation Plan per task in `docs/PHASE_N_NOTES.md` | [docs/playbooks/impl-brief.md](docs/playbooks/impl-brief.md) |
 | `/impl-assist [N] [ID\|group]` | Have the agent implement uncompleted tasks (reads plan from `PHASE_N_NOTES.md`) | [docs/playbooks/impl-assist.md](docs/playbooks/impl-assist.md) |
+| `/project-sync [XX] [--dry-run\|--setup]` | Sync phase task checkboxes to GitHub Issues + GitHub Projects Kanban board (requires `gh` CLI + GitHub remote) | [docs/playbooks/project-sync.md](docs/playbooks/project-sync.md) |
 | `/phase-gate [N]` | Validate a phase before committing | [docs/playbooks/phase-gate.md](docs/playbooks/phase-gate.md) |
 | `/spec-sync [description]` | Immediately after editing `docs/SPEC.md` | [docs/playbooks/spec-sync.md](docs/playbooks/spec-sync.md) |
 | `/context-update [N]` | After the gate passes | [docs/playbooks/context-update.md](docs/playbooks/context-update.md) |

--- a/project-files/docs/playbooks/README.md
+++ b/project-files/docs/playbooks/README.md
@@ -9,7 +9,7 @@ There are two audiences:
    a target project. The other playbooks are shipped to the target project by `workflow-init`
    and become reachable there.
 2. **An integrated project.** After `/workflow-init` has run, the target project gets a copy of all
-   eight playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
+   nine playbooks under `docs/playbooks/`, plus thin wrapper skills/commands under `.claude/skills/`
    and `plugins/sdd-workflow/`. Those wrappers do not contain workflow logic — they point here.
 
 To change a workflow, edit only the playbook file. The wrappers stay one-line stubs.
@@ -24,6 +24,7 @@ To change a workflow, edit only the playbook file. The wrappers stay one-line st
 - [context-update.md](./context-update.md) — finalize a completed phase
 - [impl-brief.md](./impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
 - [impl-assist.md](./impl-assist.md) — implement uncompleted phase tasks (optional)
+- [project-sync.md](./project-sync.md) — sync phase tasks to GitHub Issues + GitHub Projects board (optional, GitHub-specific)
 
 ## Stack-specific commands
 

--- a/project-files/docs/playbooks/project-sync.md
+++ b/project-files/docs/playbooks/project-sync.md
@@ -146,7 +146,7 @@ phase, key, and title). Print a summary count per operation type. Stop. Do not c
 Execute queued operations in this order: `create` → `update-title` → `archive` → `close` →
 `reopen` → `set-column`.
 
-**create**
+#### create
 
 ```bash
 gh issue create \
@@ -170,7 +170,7 @@ gh project item-edit --project-id <project_id> --id <item_id> \
   --field-id <status_field_id> --single-select-option-id <target_option_id>
 ```
 
-**update-title**
+#### update-title
 
 ```bash
 gh issue edit <number> --repo <owner>/<repo> --title "[PHASE_XX][KEY] <new_title>"

--- a/project-files/docs/playbooks/project-sync.md
+++ b/project-files/docs/playbooks/project-sync.md
@@ -1,0 +1,289 @@
+# project-sync — Canonical Playbook
+
+Mirror the current state of all `docs/PHASE_XX.md` task checkboxes to GitHub Issues and a GitHub
+Projects v2 Kanban board. Idempotent — safe to run on every commit or on demand.
+
+This document is the single source of truth for the `project-sync` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/project-sync/SKILL.md` (Claude
+Code) and `plugins/sdd-workflow/{commands,skills}/project-sync/…` (Codex) point here. The wrappers
+are thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/project-sync                   — sync all phases to the GitHub board
+/project-sync [XX]              — sync single phase (two-digit, e.g. 01)
+/project-sync --dry-run         — print diff without applying any changes
+/project-sync --setup           — create GitHub Project + columns + sdd-workflow label; write config to docs/STACK.md
+/project-sync [XX] --dry-run    — dry-run for a single phase
+```
+
+- `XX` — zero-padded phase number (e.g. `01`). If omitted, all discovered `docs/PHASE_XX.md` files
+  are processed.
+- `--dry-run` — compute and print the full change queue but do not call any GitHub write API.
+- `--setup` — one-time initialisation: creates a GitHub Project, status columns, and the
+  `sdd-workflow` label; writes config to `docs/STACK.md § GitHub Project`. Must be run before the
+  first sync.
+
+## Source of truth
+
+The markdown files are always the source of truth. The GitHub board is a read-only view.
+Writing back from GitHub to markdown (e.g. issue closed on GitHub → uncheck box) is out of scope
+to avoid two-source-of-truth problems.
+
+## Required reads
+
+- `docs/PHASE_XX.md` (all, or specified) — task checkboxes and phase status
+- `docs/STATE.md` — phase status cross-check (informational only)
+- `docs/STACK.md § GitHub Project` — project number and field IDs written by `--setup`
+
+## Idempotency mechanism
+
+Every GitHub Issue created by this workflow has a hidden marker in its body:
+
+```
+<!-- sdd-sync: PHASE_01/B1 -->
+```
+
+On every run the workflow fetches all issues labelled `sdd-workflow`, parses their markers, builds
+a lookup map `(PHASE_XX/KEY) → {issue_number, state, project_item_id}`, diffs against current
+markdown state, and applies only the delta.
+
+## Task key derivation
+
+- If a scope item contains an explicit bracket ID (e.g. `**[B1]**`, `[F2]`, `[I3]`): use that as
+  the key verbatim (e.g. `B1`, `F2`).
+- Otherwise: derive a positional key `T01`, `T02`, … (sequential index within `## Scope`, 1-based,
+  zero-padded to two digits).
+- Key format in the marker: `PHASE_XX/B1` or `PHASE_XX/T01`.
+
+## Status → Project column mapping
+
+| Markdown state | Project column |
+|----------------|----------------|
+| task `[ ]`, phase `⏳ pending` | Todo |
+| task `[ ]`, phase `🔄 in-progress` | In Progress |
+| task `[ ]`, phase `⚠️ NEEDS_REVIEW` | Needs Review |
+| task `[ ]`, phase `❌ blocked` | Blocked |
+| task `[x]` (any phase status) | Done |
+
+## Full lifecycle operations
+
+| Trigger | Operation |
+|---------|-----------|
+| Task in markdown, no matching issue | Create issue + add to project + set column |
+| Task title changed (same key) | Update issue title |
+| Task `[ ]`, matching issue is closed (not `sdd-removed`) | Reopen issue + set column |
+| Task `[x]`, matching issue is open | Close issue + set column to Done |
+| Issue column differs from expected | Set column |
+| Task removed from `## Scope` | Close issue + add label `sdd-removed` |
+| No change | No-op |
+
+## Procedure
+
+### Step 1 — Prerequisite check
+
+1. If `--setup` flag is present: run the **Setup sub-procedure** (§ below), then stop.
+2. Check `gh auth status`. If not authenticated, stop:
+   > "Not authenticated. Run `gh auth login` first, then re-run `/project-sync`."
+3. Confirm remote is GitHub: `git remote get-url origin`. Extract `<owner>/<repo>`. If the remote
+   is not a github.com URL, stop with a clear message.
+4. Read `docs/STACK.md § GitHub Project`. If the section does not exist, stop:
+   > "GitHub Project not configured. Run `/project-sync --setup` first."
+5. Extract from the section: `project_number`, `status_field_id`, and option IDs for each column
+   (Todo, In Progress, Needs Review, Blocked, Done).
+
+### Step 2 — Parse markdown state
+
+1. Discover phase files: `docs/PHASE_XX.md` matching the pattern (all, or only the specified `XX`).
+2. For each phase file extract:
+   - `phase_number` — from filename (e.g. `01`)
+   - `phase_title` — from the `# PHASE XX — …` header line
+   - `phase_status` — from the `Status` row of `## Phase Metadata` table (emoji + word)
+   - `scope_items[]` — every `- [ ]` or `- [x]` line under `## Scope`:
+     - `key` — explicit `[ID]` from the line if present, else `T<NN>` (positional)
+     - `title` — text of the checkbox item, stripped of the ID prefix
+     - `checked` — `true` if `[x]` or `[X]`, `false` if `[ ]`
+
+### Step 3 — Fetch GitHub state
+
+1. Run:
+   ```bash
+   gh issue list --repo <owner>/<repo> --label sdd-workflow --state all --limit 500 \
+     --json number,title,state,body,labels
+   ```
+2. For each issue, parse `<!-- sdd-sync: PHASE_XX/KEY -->` from the body.
+3. Build lookup map: `(PHASE_XX/KEY) → {number, state}`.
+4. To get `project_item_id` for column updates: query the project's items via
+   `gh project item-list <project_number> --owner <owner> --format json --limit 500` and join on
+   issue URL.
+
+### Step 4 — Compute diff
+
+For each scope item in each phase file:
+
+1. Compute `target_column` from the status mapping table above.
+2. Look up `(PHASE_XX/KEY)` in the GitHub map:
+   - **Not found** → QUEUE `create`
+   - **Found, title differs** → QUEUE `update-title`
+   - **Found, issue closed (not `sdd-removed`) + task unchecked** → QUEUE `reopen`
+   - **Found, issue open + task checked** → QUEUE `close`
+   - **Found, open + unchecked, column differs from target** → QUEUE `set-column`
+   - **Otherwise** → no-op
+
+For each GitHub issue whose `(PHASE_XX/KEY)` is NOT present in any parsed phase file:
+
+- If issue does NOT already have label `sdd-removed` → QUEUE `archive`
+
+### Step 5 — Dry-run check
+
+If `--dry-run` was passed: print the full diff queue (all queued operations with their type,
+phase, key, and title). Print a summary count per operation type. Stop. Do not call any write API.
+
+### Step 6 — Apply changes
+
+Execute queued operations in this order: `create` → `update-title` → `archive` → `close` →
+`reopen` → `set-column`.
+
+**create**
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "[PHASE_XX][KEY] <title>" \
+  --body "<!-- sdd-sync: PHASE_XX/KEY -->
+**Phase:** PHASE_XX — <phase_title>
+**Task ID:** KEY
+
+---
+_Synced from \`docs/PHASE_XX.md\` by \`/project-sync\`_" \
+  --label sdd-workflow \
+  --label phase-XX
+```
+
+Then add to project and set column:
+
+```bash
+gh project item-add <project_number> --owner <owner> --url <issue_url>
+gh project item-edit --project-id <project_id> --id <item_id> \
+  --field-id <status_field_id> --single-select-option-id <target_option_id>
+```
+
+**update-title**
+
+```bash
+gh issue edit <number> --repo <owner>/<repo> --title "[PHASE_XX][KEY] <new_title>"
+```
+
+**archive** (task removed from scope)
+
+```bash
+gh issue edit <number> --repo <owner>/<repo> --add-label sdd-removed
+gh issue close <number> --repo <owner>/<repo>
+```
+
+**close** (task completed in markdown)
+
+```bash
+gh issue close <number> --repo <owner>/<repo>
+gh project item-edit ... --single-select-option-id <done_option_id>
+```
+
+**reopen** (task unchecked in markdown, issue was closed)
+
+```bash
+gh issue reopen <number> --repo <owner>/<repo>
+gh project item-edit ... --single-select-option-id <target_option_id>
+```
+
+**set-column** (column out of sync)
+
+```bash
+gh project item-edit --project-id <project_id> --id <item_id> \
+  --field-id <status_field_id> --single-select-option-id <target_option_id>
+```
+
+### Step 7 — Report
+
+```
+## project-sync complete
+
+Phase(s): PHASE_01, PHASE_02
+GitHub repo: <owner>/<repo>  |  Project: #<N>
+
+Created:   3 issues
+Updated:   1 issue title
+Closed:    2 issues (done)
+Reopened:  0
+Archived:  1 issue (removed from scope)
+Column:    4 issues re-placed
+No-op:     12 issues
+
+Next: view board at https://github.com/orgs/<owner>/projects/<N>
+  or run `/project-sync --dry-run` to preview future changes.
+```
+
+---
+
+## Setup sub-procedure (`--setup`)
+
+Run once per project before the first `/project-sync`.
+
+1. Check `docs/STACK.md` for an existing `## GitHub Project` section. If found, ask the user
+   to confirm overwrite before continuing.
+2. Determine `<owner>` from `git remote get-url origin`.
+3. Create the GitHub Project:
+   ```bash
+   gh project create --owner <owner> --title "<ProjectName> Board" --format json
+   ```
+   Capture `project_number` and `project_id` from output.
+4. Add a single-select Status field with five options — **Todo**, **In Progress**,
+   **Needs Review**, **Blocked**, **Done** — using the GraphQL mutation
+   `addProjectV2SingleSelectField` via `gh api graphql`.
+5. Fetch the field ID and option IDs:
+   ```bash
+   gh project field-list <project_number> --owner <owner> --format json
+   ```
+6. Create the `sdd-workflow` label if it does not exist:
+   ```bash
+   gh label create sdd-workflow --color 0075ca --repo <owner>/<repo>
+   ```
+7. Append (or replace) `## GitHub Project` section in `docs/STACK.md`:
+   ```markdown
+   ## GitHub Project
+
+   | Key | Value |
+   |-----|-------|
+   | Project number | `<N>` |
+   | Project ID | `<PVT_xxx>` |
+   | Status field ID | `<PVTSSF_xxx>` |
+   | Option: Todo | `<opt-id-todo>` |
+   | Option: In Progress | `<opt-id-inprogress>` |
+   | Option: Needs Review | `<opt-id-needsreview>` |
+   | Option: Blocked | `<opt-id-blocked>` |
+   | Option: Done | `<opt-id-done>` |
+   ```
+8. Report: "Setup complete. Run `/project-sync` to perform the first sync."
+
+---
+
+## Rules
+
+- Never modify any `docs/PHASE_XX.md` or other markdown file.
+- Never hard-delete GitHub Issues — only close + label `sdd-removed`.
+- `--dry-run` must not call any write API. All reads are allowed.
+- If any `gh` command fails (network, auth, rate limit): stop immediately. Print the failed
+  command and the error. Do not silently swallow errors or skip remaining items.
+- Cap issue body at 2 000 characters. Truncate with `…(see docs/PHASE_XX.md)` if needed.
+- If `docs/STACK.md` has no `## GitHub Project` section and `--setup` was not passed: stop with
+  the prescribed message from Step 1. Do not create the section automatically.
+- Issues labelled `sdd-removed` are never reopened by the sync, even if a task with the same
+  key reappears (treat as a new task → create a new issue).
+
+## Done when
+
+- `--setup`: `docs/STACK.md § GitHub Project` exists with all field IDs filled.
+- Sync: all scope items from targeted phase files have a corresponding open or closed GitHub Issue
+  with the correct sync marker, title, column placement, and open/closed state.
+- The report lists created, updated, closed, reopened, archived, column-changed, and no-op counts.

--- a/project-files/docs/playbooks/workflow-init.md
+++ b/project-files/docs/playbooks/workflow-init.md
@@ -112,12 +112,13 @@ Files to copy from `project-files/` to the target root, preserving structure:
 - `AGENTS.md` → `AGENTS.md`
 - `CLAUDE.md` → `CLAUDE.md`
 - `.mcp.json` → `.mcp.json`
-- `.claude/skills/<7 skills>/SKILL.md` → `.claude/skills/<7 skills>/SKILL.md`
-  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist)
+- `.claude/skills/<8 skills>/SKILL.md` → `.claude/skills/<8 skills>/SKILL.md`
+  (spec-init, phase-init, phase-gate, spec-sync, context-update, impl-brief, impl-assist,
+  project-sync)
 - `plugins/sdd-workflow/` → `plugins/sdd-workflow/` (commands, skills, hooks.json, .mcp.json,
   .codex-plugin/, scripts/, README.md)
-- `docs/playbooks/<8 playbooks>.md` → `docs/playbooks/<8 playbooks>.md` (includes `workflow-init.md`
-  for future-self reference, plus `impl-brief.md` and `impl-assist.md`)
+- `docs/playbooks/<9 playbooks>.md` → `docs/playbooks/<9 playbooks>.md` (includes `workflow-init.md`
+  for future-self reference, plus `impl-brief.md`, `impl-assist.md`, and `project-sync.md`)
 - `docs/templates/SPEC.md` → `docs/SPEC.md` (only if missing)
 - `docs/templates/STATE.md` → `docs/STATE.md` (only if missing)
 - `docs/templates/CHANGELOG.md` → `docs/CHANGELOG.md` (only if missing)
@@ -195,8 +196,8 @@ Produce a short report with:
 
 ## Done when
 
-- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<7>`, `plugins/sdd-workflow/`,
-  `docs/playbooks/<8>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
+- The target project has `AGENTS.md`, `CLAUDE.md`, `.claude/skills/<8>`, `plugins/sdd-workflow/`,
+  `docs/playbooks/<9>`, and seeded `docs/{SPEC,STATE,CHANGELOG,CONTEXT,STACK,KNOWN_GOTCHAS,
   DECISIONS,PHASE_TEMPLATE,PHASE_NOTES_TEMPLATE}.md`.
 - `docs/STACK.md` either has user-supplied gate commands or is flagged for the user to fill in.
 - The user has the exact "next steps" list and knows the cloned `sdd-workflow` checkout can be

--- a/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
+++ b/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
@@ -16,7 +16,10 @@
     "context7",
     "impl-brief",
     "impl-assist",
-    "human-implementation"
+    "human-implementation",
+    "project-sync",
+    "github-projects",
+    "kanban"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/project-files/plugins/sdd-workflow/README.md
+++ b/project-files/plugins/sdd-workflow/README.md
@@ -16,6 +16,7 @@ This plugin makes the project's SDD workflow visible to Codex as native:
 - `/spec-sync`
 - `/impl-brief` — generate a concrete implementation plan for phase tasks (optional)
 - `/impl-assist` — implement uncompleted phase tasks (optional)
+- `/project-sync` — sync phase tasks to GitHub Issues + GitHub Projects board (optional, requires `gh` CLI + GitHub remote)
 
 The plugin mirrors the Claude Code wrappers in `.claude/skills/`. Both runtimes point at the same canonical playbooks under `docs/playbooks/`.
 

--- a/project-files/plugins/sdd-workflow/commands/project-sync.md
+++ b/project-files/plugins/sdd-workflow/commands/project-sync.md
@@ -1,0 +1,16 @@
+---
+description: Sync phase task checkboxes to GitHub Issues + GitHub Projects Kanban board. Idempotent. Usage: /project-sync [XX] [--dry-run] [--setup]
+---
+
+# /project-sync
+
+Execute the canonical playbook: [docs/playbooks/project-sync.md](../../../docs/playbooks/project-sync.md).
+
+The matching skill lives at [skills/project-sync/SKILL.md](../skills/project-sync/SKILL.md).
+
+Parse $ARGUMENTS:
+- No args → sync all phases
+- A two-digit number (e.g. `01`) → sync that phase only
+- `--setup` → run initial GitHub Project creation and write config to `docs/STACK.md`
+- `--dry-run` → print diff, apply nothing
+- Combinations allowed: e.g. `01 --dry-run`

--- a/project-files/plugins/sdd-workflow/skills/project-sync/SKILL.md
+++ b/project-files/plugins/sdd-workflow/skills/project-sync/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: project-sync
+description: Sync phase task checkboxes from docs/PHASE_XX.md to GitHub Issues and a GitHub Projects v2 Kanban board. Idempotent — diffing on sync marker in issue body. Supports --setup, --dry-run, and per-phase targeting.
+metadata:
+  priority: 6
+  pathPatterns:
+    - 'docs/PHASE_*.md'
+    - 'docs/STATE.md'
+    - 'docs/STACK.md'
+  promptSignals:
+    phrases:
+      - "project sync"
+      - "sync to github"
+      - "sync kanban"
+      - "sync board"
+      - "github board"
+      - "github project"
+    allOf:
+      - [sync, github]
+    anyOf:
+      - "kanban"
+      - "board"
+      - "issues"
+    noneOf: []
+    minScore: 5
+retrieval:
+  aliases:
+    - sync tasks to github
+    - update kanban board
+    - push phase tasks to github projects
+  intents:
+    - mirror markdown task state to GitHub Projects board
+    - keep github issues in sync with phase files
+  entities:
+    - PHASE_XX.md
+    - GitHub Projects
+    - GitHub Issues
+---
+
+# project-sync
+
+Execute the canonical playbook in [docs/playbooks/project-sync.md](../../../../docs/playbooks/project-sync.md). That file is the source of truth for all steps, the idempotency mechanism, the full lifecycle operations, and the report format.


### PR DESCRIPTION
## Summary

- New `/project-sync [XX] [--dry-run] [--setup]` skill that mirrors `docs/PHASE_XX.md` task checkboxes to GitHub Issues + GitHub Projects v2 Kanban board
- Idempotency via hidden `<!-- sdd-sync: PHASE_XX/KEY -->` marker in each issue body — repeated runs apply only the delta
- Full lifecycle: create, update-title, close (task `[x]`), reopen (task unchecked), archive (task removed from scope), column placement

## Key design decisions

- **One issue per task** (not per phase) for proper per-task Kanban cards
- **Markdown is source of truth** — GitHub board is a read-only mirror; no write-back to markdown
- **Config in `docs/STACK.md § GitHub Project`** — `--setup` writes project number + field/option IDs once; subsequent syncs read it without extra API calls
- **Task keys**: explicit `[B1]`-style IDs when present, else positional `T01`, `T02`, …
- **Column mapping**: phase status emoji (`⏳ pending` → Todo, `🔄 in-progress` → In Progress, `⚠️` → Needs Review, `❌` → Blocked) + task checkbox (`[x]` → Done)

## Files changed

**New (5):**
- `docs/playbooks/project-sync.md` — canonical playbook
- `project-files/docs/playbooks/project-sync.md` — mirror
- `project-files/.claude/skills/project-sync/SKILL.md`
- `project-files/plugins/sdd-workflow/skills/project-sync/SKILL.md`
- `project-files/plugins/sdd-workflow/commands/project-sync.md`

**Updated (10):** workflow-init counts (7→8 skills, 8→9 playbooks), README playbook lists, CLAUDE.md + AGENTS.md skill tables, plugin.json keywords

## Test plan

- [ ] Read `docs/playbooks/project-sync.md` top-to-bottom: --dry-run exits before Step 6, marker-not-found triggers create not update, archived issues are never reopened
- [ ] `grep "project-sync" project-files/CLAUDE.md` — row present
- [ ] `grep "<8 skills>" docs/playbooks/workflow-init.md` — count updated
- [ ] `ls project-files/plugins/sdd-workflow/skills/project-sync/` — SKILL.md present