### PR TITLE
feat: add /phase-explore skill — explicit exploration stage before impl-brief

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ If you find logic in a wrapper, push it to the playbook and shrink the wrapper b
 
 ## Don't run derived-project skills against this repo
 
-`/spec-init`, `/phase-init`, `/phase-gate`, `/spec-sync`, `/context-update`, `/impl-brief`,
-`/impl-assist`, `/project-sync` are intended for integrated projects. Do not invoke them against
+`/spec-init`, `/phase-init`, `/phase-explore`, `/phase-gate`, `/spec-sync`, `/context-update`,
+`/impl-brief`, `/impl-assist`, `/project-sync` are intended for integrated projects. Do not invoke them against
 this repo's `docs/`. The only skill that runs from here is `/workflow-init`, and it must be run
 with a target path pointing **outside** this repo.
 
@@ -91,15 +91,15 @@ skill is idempotent and only overwrites versioned files (wrappers, playbooks).
 ```
 sdd-workflow/
 ├── docs/
-│   ├── playbooks/           # CANONICAL workflow procedures (9 files)
+│   ├── playbooks/           # CANONICAL workflow procedures (10 files)
 │   └── CONTRIBUTING.md
 ├── project-files/           # Source for everything /workflow-init copies into a target project
 │   ├── AGENTS.md
 │   ├── CLAUDE.md
 │   ├── .mcp.json
-│   ├── .claude/skills/<8>/SKILL.md
+│   ├── .claude/skills/<9>/SKILL.md
 │   ├── plugins/sdd-workflow/
-│   ├── docs/playbooks/<9>.md  (mirror of docs/playbooks/)
+│   ├── docs/playbooks/<10>.md  (mirror of docs/playbooks/)
 │   └── docs/templates/<8 doc scaffolds>
 ├── .claude/skills/workflow-init/SKILL.md
 ├── plugins/sdd-workflow/      # Bootstrap-only Codex plugin (just /workflow-init)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file adds only Claude-specific notes.
 
 ## Scope reminder
 
-This repo IS the workflow bundle. Do not run `/spec-init`, `/phase-init`, `/phase-gate`,
+This repo IS the workflow bundle. Do not run `/spec-init`, `/phase-init`, `/phase-explore`, `/phase-gate`,
 `/spec-sync`, `/context-update`, `/impl-brief`, `/impl-assist`, or `/project-sync` against this
 repo's `docs/` — those skills are shipped to integrated projects. The only skill that runs from
 here is `/workflow-init <target-path>`, and the target must be **outside** this repo.
@@ -18,6 +18,7 @@ here is `/workflow-init <target-path>`, and the target must be **outside** this 
 | `/workflow-init` | [`docs/playbooks/workflow-init.md`](docs/playbooks/workflow-init.md) |
 | `/spec-init` (in integrated projects) | [`docs/playbooks/spec-init.md`](docs/playbooks/spec-init.md) |
 | `/phase-init` (in integrated projects) | [`docs/playbooks/phase-init.md`](docs/playbooks/phase-init.md) |
+| `/phase-explore` (in integrated projects) | [`docs/playbooks/phase-explore.md`](docs/playbooks/phase-explore.md) |
 | `/phase-gate` (in integrated projects) | [`docs/playbooks/phase-gate.md`](docs/playbooks/phase-gate.md) |
 | `/spec-sync` (in integrated projects) | [`docs/playbooks/spec-sync.md`](docs/playbooks/spec-sync.md) |
 | `/context-update` (in integrated projects) | [`docs/playbooks/context-update.md`](docs/playbooks/context-update.md) |

--- a/docs/playbooks/impl-brief.md
+++ b/docs/playbooks/impl-brief.md
@@ -46,7 +46,16 @@ thin stubs — every workflow detail lives in this file.
 
 ### 2. Read context
 
-For each target task:
+**Check for existing exploration first**: For each target task, check whether `### Exploration`
+in `docs/PHASE_XX_NOTES.md` is non-empty.
+
+- If non-empty: read the exploration findings (patterns, constraints, risks) and use them as the
+  primary codebase context for this task. Skip re-reading source files already documented in the
+  exploration. If the verdict line contains `needs-clarification`, stop immediately, report the
+  open question, and do not generate a plan for this task.
+- If empty or absent: proceed with the inline reads below.
+
+For each target task (where exploration was absent or incomplete):
 - Extract the task description and `Depends on:` field from `docs/PHASE_XX.md` § Scope.
 - Extract relevant contracts from `docs/PHASE_XX.md` (schemas, endpoints, types, env vars) that
   apply to this task.

--- a/docs/playbooks/phase-explore.md
+++ b/docs/playbooks/phase-explore.md
@@ -1,0 +1,158 @@
+# phase-explore — Canonical Playbook
+
+Explore the codebase in the context of one or more phase tasks and record findings in the
+`### Exploration` section(s) of `docs/PHASE_XX_NOTES.md`.
+
+This is an **optional** step that runs between `/phase-init` and `/impl-brief` for tasks that
+are non-trivial, touch unfamiliar code areas, or involve cross-cutting concerns. For simple
+additive tasks (add one endpoint or field with a clear existing analogue) it can be skipped.
+
+This document is the single source of truth for the `phase-explore` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/phase-explore/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/phase-explore/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/phase-explore [XX]                  — full phase (all tasks)
+/phase-explore [XX] [ID]             — single task, e.g. B3
+/phase-explore [XX] [group]          — group, e.g. backend | frontend | infra | data
+/phase-explore [XX] [ID] --force     — overwrite existing Exploration even if present
+/phase-explore [XX] [group] --force  — overwrite group
+```
+
+- `XX` — zero-padded phase number (e.g. `01`)
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to all tasks with the matching prefix: `backend`→`B*`, `frontend`→`F*`,
+  `infra`→`I*`, `data`→`D*`
+- `--force` — overwrite `### Exploration` even if it already has content
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts (data model, endpoints, types, env vars), files list
+- `docs/PHASE_XX_NOTES.md` — existing Exploration sections; used for the skip check
+- `docs/CONTEXT.md` — current active models, endpoints, db schema
+- `docs/STACK.md` — project layout, naming conventions, stack-specific patterns
+- `docs/KNOWN_GOTCHAS.md` — known pitfalls relevant to the task domain
+- Relevant source files — read actual code to discover patterns, invariants, constraints
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number provided, ask: "Which phase and task? e.g. /phase-explore 01 B3 or /phase-explore 01 backend"
+- Normalize phase number to two digits: `2` → `02`, `10` → `10`.
+- If `docs/PHASE_XX_NOTES.md` does not exist, stop: "docs/PHASE_[XX]_NOTES.md not found. Run /phase-init [XX] first."
+- Resolve target task list from the input scope argument (see Input section above).
+
+### 2. Skip check
+
+For each target task: if `### Exploration` already has non-empty content AND `--force` was not
+passed — mark as SKIPPED and do not overwrite. Log the skip in the report.
+
+### 3. Explore codebase
+
+For each non-skipped task:
+
+**a. Read scope and contracts.** Extract the task description and `Depends on:` chain from
+`docs/PHASE_XX.md § Scope`. Extract contracts (schemas, endpoints, types, env vars) that apply
+to this task. Note any files explicitly listed in `docs/PHASE_XX.md § Files`.
+
+**b. Identify relevant source files.** Based on the task domain and contracts, identify which
+existing files are most likely to be involved:
+
+- Files listed in `docs/PHASE_XX.md § Files` for this task
+- Files referenced by active models/endpoints in `docs/CONTEXT.md`
+- Files in the domain area of the task (e.g. billing task → billing module)
+- Files implementing analogous patterns in adjacent resources
+
+**c. Read those files.** Scan for the following four categories:
+
+1. **Relevant patterns** — existing implementations (routes, models, services, components,
+   stores) whose structure the new task should copy or extend. Capture exact file paths and
+   line ranges.
+
+2. **Constraints discovered** — invariants, DB constraints, middleware assumptions, enum values,
+   or special-case logic present in code but not described in the spec. These are facts the
+   Implementation Plan must respect.
+
+3. **Spec/contract gaps** — discrepancies between what `PHASE_XX.md` says and what the codebase
+   reveals. Examples: spec omits pagination but all similar endpoints use it; a required env var
+   is missing from Contracts; a column type conflicts with an existing foreign key.
+
+4. **Risk areas** — complex logic touched by this task, broad file impact, migration risks,
+   test coverage gaps in affected modules.
+
+**d. Determine verdict:**
+
+- `ready` — no blockers found; `/impl-brief` can produce a sound plan without further input.
+- `needs-clarification: [specific question]` — found an issue requiring a human decision
+  before a plan can be written. State the question precisely and concisely.
+
+### 4. Write to PHASE_XX_NOTES.md
+
+Using surgical edits (not full-file rewrite): replace the empty `### Exploration` content
+(or overwrite if `--force`) for each target task. Preserve all other file content unchanged,
+including any existing `### Implementation Plan` and `### Decisions & Notes` entries.
+
+Write the following structure into the `### Exploration` section:
+
+```markdown
+_Explored:_ `YYYY-MM-DD` · _Verdict:_ `ready`
+
+**Relevant patterns found:**
+- `path/to/file.ext:LNN` — [description of pattern and how it applies]
+
+**Constraints discovered:**
+- [constraint present in code but not captured in spec]
+
+**Spec/contract gaps:**
+- [discrepancy between PHASE_XX.md and the actual codebase]
+
+**Risk areas:**
+- [risk or test coverage gap]
+```
+
+Use `—` for any sub-section where nothing was found. Keep entries concise — one line per
+finding. If verdict is `needs-clarification`, write:
+`_Verdict:_ \`needs-clarification: [question]\``
+
+### 5. Report
+
+```
+## phase-explore complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Written:
+  [ID] — [task name]: docs/PHASE_[XX]_NOTES.md § Exploration ✅
+    Verdict: ready
+
+Skipped (already has content — use --force to overwrite):
+  [ID] — [task name]
+
+[If any needs-clarification verdicts:]
+⚠ Open questions — resolve before running /impl-brief:
+  [ID]: [question]
+
+Next: run `/impl-brief [XX] [ID]` to generate Implementation Plans.
+(Skip any tasks with needs-clarification verdict until resolved.)
+```
+
+## Rules
+
+- Never write to `### Implementation Plan` or `### Decisions & Notes`.
+- Never modify `docs/PHASE_XX.md`, `docs/SPEC.md`, `docs/CONTEXT.md`, or `docs/STATE.md`.
+- Do not generate an Implementation Plan — that is `/impl-brief`'s responsibility.
+- Do not commit.
+- If verdict is `needs-clarification`: record it in the Exploration section, surface it in
+  the report, and stop — do not proceed to planning or implementation.
+
+## Done when
+
+- `### Exploration` section for each targeted (non-skipped) task has content.
+- Each written exploration has a verdict (`ready` or `needs-clarification: [question]`).
+- The report lists all written and skipped tasks and surfaces any open clarification questions.

--- a/project-files/.claude/skills/phase-explore/SKILL.md
+++ b/project-files/.claude/skills/phase-explore/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: phase-explore
+description: Explore the codebase in the context of phase tasks. Reads source files, records patterns/constraints/risks/spec-gaps in ### Exploration sections of PHASE_XX_NOTES.md, and emits a verdict (ready or needs-clarification). Optional step between /phase-init and /impl-brief for non-trivial tasks.
+allowed-tools: Read, Glob, Bash
+argument-hint: "[phase] [task-id | group | --force]"
+---
+
+You are running the SDD `phase-explore` workflow.
+
+**Arguments**: $ARGUMENTS
+
+Execute the canonical playbook in [docs/playbooks/phase-explore.md](../../../docs/playbooks/phase-explore.md). That file is the source of truth for scope resolution, exploration format, skip rules, and the final report.
+
+If `$ARGUMENTS` is empty, ask: "Which phase and task? e.g. /phase-explore 01 B3 or /phase-explore 01 backend"

--- a/project-files/AGENTS.md
+++ b/project-files/AGENTS.md
@@ -100,6 +100,7 @@ The SDD workflows are defined in `docs/playbooks/`:
 - [`spec-sync`](docs/playbooks/spec-sync.md) — propagate a `docs/SPEC.md` change
 - [`context-update`](docs/playbooks/context-update.md) — finalize a completed phase
 - [`impl-brief`](docs/playbooks/impl-brief.md) — generate a concrete implementation plan for phase tasks (optional)
+- [`phase-explore`](docs/playbooks/phase-explore.md) — explore the codebase for task context before planning (optional)
 - [`impl-assist`](docs/playbooks/impl-assist.md) — implement uncompleted phase tasks (optional)
 - [`project-sync`](docs/playbooks/project-sync.md) — sync phase tasks to GitHub Issues + GitHub Projects board (optional; requires `gh` CLI and a GitHub remote)
 
@@ -120,6 +121,8 @@ The runtime wrappers are thin stubs — all workflow logic lives in `docs/playbo
 4.  Architect fills Contracts + Files sections
 5.  Implement scope on feat/phase-N branch:
     - Human developer works against the Scope checklist in PHASE_N.md
+    - Optional: `/phase-explore N [task-id|group]` → explores codebase in task context, writes
+      Exploration findings to PHASE_N_NOTES.md; emits verdict `ready` or `needs-clarification`
     - Optional: `/impl-brief N [task-id|group]`  → generates Implementation Plan in PHASE_N_NOTES.md
     - Optional: `/impl-assist N [task-id|group]` → agent implements uncompleted tasks
 6.  phase-gate N      → automated baseline
@@ -156,6 +159,7 @@ The runtime wrappers are thin stubs — all workflow logic lives in `docs/playbo
 
 | Section | Owner | Agent behaviour |
 |---------|-------|-----------------|
+| `### Exploration` | Agent (phase-explore) | Written once; re-run with `--force` to overwrite |
 | `### Implementation Plan` | Agent (impl-brief) | Written once; re-run with `--force` to overwrite |
 | `### Decisions & Notes` | Human only | Never read or written by any agent |
 

--- a/project-files/CLAUDE.md
+++ b/project-files/CLAUDE.md
@@ -10,6 +10,7 @@ This file only adds Claude-specific items.
 |---------|-------------|----------------|
 | `/spec-init [--new\|--continue] [project brief]` | Draft, reset, or continue `docs/SPEC.md` from high-level requirements | [docs/playbooks/spec-init.md](docs/playbooks/spec-init.md) |
 | `/phase-init [N]` | Scaffold the next `docs/PHASE_XX.md` from SPEC | [docs/playbooks/phase-init.md](docs/playbooks/phase-init.md) |
+| `/phase-explore [N] [ID\|group]` | Before planning: explore codebase in task context, capture patterns/constraints/risks | [docs/playbooks/phase-explore.md](docs/playbooks/phase-explore.md) |
 | `/impl-brief [N] [ID\|group]` | Before implementing: generate a concrete Implementation Plan per task in `docs/PHASE_N_NOTES.md` | [docs/playbooks/impl-brief.md](docs/playbooks/impl-brief.md) |
 | `/impl-assist [N] [ID\|group]` | Have the agent implement uncompleted tasks (reads plan from `PHASE_N_NOTES.md`) | [docs/playbooks/impl-assist.md](docs/playbooks/impl-assist.md) |
 | `/project-sync [XX] [--dry-run\|--setup]` | Sync phase task checkboxes to GitHub Issues + GitHub Projects Kanban board (requires `gh` CLI + GitHub remote) | [docs/playbooks/project-sync.md](docs/playbooks/project-sync.md) |

--- a/project-files/docs/playbooks/impl-brief.md
+++ b/project-files/docs/playbooks/impl-brief.md
@@ -46,7 +46,16 @@ thin stubs — every workflow detail lives in this file.
 
 ### 2. Read context
 
-For each target task:
+**Check for existing exploration first**: For each target task, check whether `### Exploration`
+in `docs/PHASE_XX_NOTES.md` is non-empty.
+
+- If non-empty: read the exploration findings (patterns, constraints, risks) and use them as the
+  primary codebase context for this task. Skip re-reading source files already documented in the
+  exploration. If the verdict line contains `needs-clarification`, stop immediately, report the
+  open question, and do not generate a plan for this task.
+- If empty or absent: proceed with the inline reads below.
+
+For each target task (where exploration was absent or incomplete):
 - Extract the task description and `Depends on:` field from `docs/PHASE_XX.md` § Scope.
 - Extract relevant contracts from `docs/PHASE_XX.md` (schemas, endpoints, types, env vars) that
   apply to this task.

--- a/project-files/docs/playbooks/phase-explore.md
+++ b/project-files/docs/playbooks/phase-explore.md
@@ -1,0 +1,158 @@
+# phase-explore — Canonical Playbook
+
+Explore the codebase in the context of one or more phase tasks and record findings in the
+`### Exploration` section(s) of `docs/PHASE_XX_NOTES.md`.
+
+This is an **optional** step that runs between `/phase-init` and `/impl-brief` for tasks that
+are non-trivial, touch unfamiliar code areas, or involve cross-cutting concerns. For simple
+additive tasks (add one endpoint or field with a clear existing analogue) it can be skipped.
+
+This document is the single source of truth for the `phase-explore` workflow.
+
+In an integrated project, runtime wrappers under `.claude/skills/phase-explore/SKILL.md` (Claude Code)
+and `plugins/sdd-workflow/{commands,skills}/phase-explore/…` (Codex) point here. The wrappers are
+thin stubs — every workflow detail lives in this file.
+
+## Input
+
+```
+/phase-explore [XX]                  — full phase (all tasks)
+/phase-explore [XX] [ID]             — single task, e.g. B3
+/phase-explore [XX] [group]          — group, e.g. backend | frontend | infra | data
+/phase-explore [XX] [ID] --force     — overwrite existing Exploration even if present
+/phase-explore [XX] [group] --force  — overwrite group
+```
+
+- `XX` — zero-padded phase number (e.g. `01`)
+- `ID` — task identifier from the Scope checklist (e.g. `B3`, `F1`)
+- Group names resolve to all tasks with the matching prefix: `backend`→`B*`, `frontend`→`F*`,
+  `infra`→`I*`, `data`→`D*`
+- `--force` — overwrite `### Exploration` even if it already has content
+
+## Required reads
+
+- `docs/PHASE_XX.md` — scope checklist, contracts (data model, endpoints, types, env vars), files list
+- `docs/PHASE_XX_NOTES.md` — existing Exploration sections; used for the skip check
+- `docs/CONTEXT.md` — current active models, endpoints, db schema
+- `docs/STACK.md` — project layout, naming conventions, stack-specific patterns
+- `docs/KNOWN_GOTCHAS.md` — known pitfalls relevant to the task domain
+- Relevant source files — read actual code to discover patterns, invariants, constraints
+
+## Procedure
+
+### 1. Validate input
+
+- If no phase number provided, ask: "Which phase and task? e.g. /phase-explore 01 B3 or /phase-explore 01 backend"
+- Normalize phase number to two digits: `2` → `02`, `10` → `10`.
+- If `docs/PHASE_XX_NOTES.md` does not exist, stop: "docs/PHASE_[XX]_NOTES.md not found. Run /phase-init [XX] first."
+- Resolve target task list from the input scope argument (see Input section above).
+
+### 2. Skip check
+
+For each target task: if `### Exploration` already has non-empty content AND `--force` was not
+passed — mark as SKIPPED and do not overwrite. Log the skip in the report.
+
+### 3. Explore codebase
+
+For each non-skipped task:
+
+**a. Read scope and contracts.** Extract the task description and `Depends on:` chain from
+`docs/PHASE_XX.md § Scope`. Extract contracts (schemas, endpoints, types, env vars) that apply
+to this task. Note any files explicitly listed in `docs/PHASE_XX.md § Files`.
+
+**b. Identify relevant source files.** Based on the task domain and contracts, identify which
+existing files are most likely to be involved:
+
+- Files listed in `docs/PHASE_XX.md § Files` for this task
+- Files referenced by active models/endpoints in `docs/CONTEXT.md`
+- Files in the domain area of the task (e.g. billing task → billing module)
+- Files implementing analogous patterns in adjacent resources
+
+**c. Read those files.** Scan for the following four categories:
+
+1. **Relevant patterns** — existing implementations (routes, models, services, components,
+   stores) whose structure the new task should copy or extend. Capture exact file paths and
+   line ranges.
+
+2. **Constraints discovered** — invariants, DB constraints, middleware assumptions, enum values,
+   or special-case logic present in code but not described in the spec. These are facts the
+   Implementation Plan must respect.
+
+3. **Spec/contract gaps** — discrepancies between what `PHASE_XX.md` says and what the codebase
+   reveals. Examples: spec omits pagination but all similar endpoints use it; a required env var
+   is missing from Contracts; a column type conflicts with an existing foreign key.
+
+4. **Risk areas** — complex logic touched by this task, broad file impact, migration risks,
+   test coverage gaps in affected modules.
+
+**d. Determine verdict:**
+
+- `ready` — no blockers found; `/impl-brief` can produce a sound plan without further input.
+- `needs-clarification: [specific question]` — found an issue requiring a human decision
+  before a plan can be written. State the question precisely and concisely.
+
+### 4. Write to PHASE_XX_NOTES.md
+
+Using surgical edits (not full-file rewrite): replace the empty `### Exploration` content
+(or overwrite if `--force`) for each target task. Preserve all other file content unchanged,
+including any existing `### Implementation Plan` and `### Decisions & Notes` entries.
+
+Write the following structure into the `### Exploration` section:
+
+```markdown
+_Explored:_ `YYYY-MM-DD` · _Verdict:_ `ready`
+
+**Relevant patterns found:**
+- `path/to/file.ext:LNN` — [description of pattern and how it applies]
+
+**Constraints discovered:**
+- [constraint present in code but not captured in spec]
+
+**Spec/contract gaps:**
+- [discrepancy between PHASE_XX.md and the actual codebase]
+
+**Risk areas:**
+- [risk or test coverage gap]
+```
+
+Use `—` for any sub-section where nothing was found. Keep entries concise — one line per
+finding. If verdict is `needs-clarification`, write:
+`_Verdict:_ \`needs-clarification: [question]\``
+
+### 5. Report
+
+```
+## phase-explore complete
+
+Phase: PHASE_[XX]
+Scope: [resolved task list]
+
+Written:
+  [ID] — [task name]: docs/PHASE_[XX]_NOTES.md § Exploration ✅
+    Verdict: ready
+
+Skipped (already has content — use --force to overwrite):
+  [ID] — [task name]
+
+[If any needs-clarification verdicts:]
+⚠ Open questions — resolve before running /impl-brief:
+  [ID]: [question]
+
+Next: run `/impl-brief [XX] [ID]` to generate Implementation Plans.
+(Skip any tasks with needs-clarification verdict until resolved.)
+```
+
+## Rules
+
+- Never write to `### Implementation Plan` or `### Decisions & Notes`.
+- Never modify `docs/PHASE_XX.md`, `docs/SPEC.md`, `docs/CONTEXT.md`, or `docs/STATE.md`.
+- Do not generate an Implementation Plan — that is `/impl-brief`'s responsibility.
+- Do not commit.
+- If verdict is `needs-clarification`: record it in the Exploration section, surface it in
+  the report, and stop — do not proceed to planning or implementation.
+
+## Done when
+
+- `### Exploration` section for each targeted (non-skipped) task has content.
+- Each written exploration has a verdict (`ready` or `needs-clarification: [question]`).
+- The report lists all written and skipped tasks and surfaces any open clarification questions.

--- a/project-files/docs/templates/PHASE_NOTES_TEMPLATE.md
+++ b/project-files/docs/templates/PHASE_NOTES_TEMPLATE.md
@@ -5,6 +5,7 @@
   HOW it was built → this file         (plans, decisions, rationale)
 
   Ownership rules:
+  - ### Exploration          — written by agent (/phase-explore). Optional; skip for simple tasks.
   - ### Implementation Plan  — written by agent (/impl-brief). Agent may update only this section.
   - ### Decisions & Notes    — written by human. NEVER overwritten by agent.
 
@@ -21,6 +22,11 @@ _Phase:_ `[XX]` · _Generated:_ `[DATE]`
 
 ## [B1] — [task name]
 **Depends on:** —
+
+### Exploration
+<!-- Optional. Run `/phase-explore [XX] B1` to populate.
+     When filled, impl-brief uses this instead of re-reading the codebase from scratch.
+     Leave empty for simple additive tasks. -->
 
 ### Implementation Plan
 <!-- Run `/impl-brief [XX] B1` to generate. Output includes: Done when / Follows pattern / steps. -->

--- a/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
+++ b/project-files/plugins/sdd-workflow/.codex-plugin/plugin.json
@@ -19,7 +19,8 @@
     "human-implementation",
     "project-sync",
     "github-projects",
-    "kanban"
+    "kanban",
+    "phase-explore"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/project-files/plugins/sdd-workflow/commands/phase-explore.md
+++ b/project-files/plugins/sdd-workflow/commands/phase-explore.md
@@ -1,0 +1,11 @@
+---
+description: Explore codebase in task context and populate ### Exploration sections in PHASE_XX_NOTES.md before planning. Usage: /phase-explore [XX] [task-id|group] [--force]
+---
+
+# /phase-explore
+
+Execute the canonical playbook: [docs/playbooks/phase-explore.md](../../../docs/playbooks/phase-explore.md).
+
+The matching skill lives at [skills/phase-explore/SKILL.md](../skills/phase-explore/SKILL.md).
+
+If arguments are empty, ask: "Which phase and task? e.g. /phase-explore 01 B3 or /phase-explore 01 backend"

--- a/project-files/plugins/sdd-workflow/skills/phase-explore/SKILL.md
+++ b/project-files/plugins/sdd-workflow/skills/phase-explore/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: phase-explore
+description: Explore the codebase in the context of phase tasks before planning. Reads actual source files, records patterns/constraints/risks in ### Exploration sections of PHASE_XX_NOTES.md, and emits a verdict (ready or needs-clarification). Run before /impl-brief for non-trivial tasks.
+metadata:
+  priority: 5
+  pathPatterns:
+    - 'docs/PHASE_*.md'
+    - 'docs/PHASE_*_NOTES.md'
+    - 'docs/CONTEXT.md'
+    - 'docs/STACK.md'
+  promptSignals:
+    phrases:
+      - "phase explore"
+      - "explore codebase"
+      - "explore before planning"
+      - "explore tasks"
+    allOf:
+      - [phase, explore]
+    anyOf:
+      - "exploration"
+      - "codebase"
+      - "patterns"
+    noneOf: []
+    minScore: 5
+retrieval:
+  aliases:
+    - sdd phase explore
+    - explore phase tasks
+  intents:
+    - explore the codebase context before writing an implementation plan
+    - populate PHASE_XX_NOTES.md with exploration findings and verdict
+  entities:
+    - PHASE_XX_NOTES.md
+    - PHASE_XX.md
+---
+
+# phase-explore
+
+Execute the canonical playbook in [docs/playbooks/phase-explore.md](../../../../docs/playbooks/phase-explore.md). That file is the source of truth for scope resolution, exploration format, skip rules, and the final report.


### PR DESCRIPTION
## Summary

- Adds new optional skill `/phase-explore` that runs between `/phase-init` and `/impl-brief`
- Agent reads actual source files in task context and records structured findings (patterns, constraints, spec gaps, risks) in `PHASE_XX_NOTES.md` under a new `### Exploration` section
- Emits a verdict per task: `ready` (proceed to impl-brief) or `needs-clarification` (human must resolve first)
- Updates `impl-brief` to consume exploration findings when present, skipping redundant file reads and stopping hard on `needs-clarification`
- All changes are additive and backward-compatible — existing projects without exploration sections continue working as before

## Files changed

**5 new files:**
- `docs/playbooks/phase-explore.md` — canonical playbook (source of truth)
- `project-files/docs/playbooks/phase-explore.md` — mirror shipped to integrated projects
- `project-files/.claude/skills/phase-explore/SKILL.md` — Claude Code thin wrapper
- `project-files/plugins/sdd-workflow/commands/phase-explore.md` — Codex command stub
- `project-files/plugins/sdd-workflow/skills/phase-explore/SKILL.md` — Codex skill stub

**8 modified files:**
- `project-files/docs/templates/PHASE_NOTES_TEMPLATE.md` — added `### Exploration` section to task block
- `docs/playbooks/impl-brief.md` + mirror — step 2 now checks exploration before reading source files
- `project-files/AGENTS.md` — added phase-explore to Workflow Playbooks, Phase Lifecycle, file ownership table
- `project-files/CLAUDE.md` — added `/phase-explore` row to slash commands table
- `CLAUDE.md` (root) — added `/phase-explore` to skills table and scope reminder
- `AGENTS.md` (root) — updated file map counts (9→10 playbooks, 8→9 skills), added to don't-run list
- `project-files/plugins/sdd-workflow/.codex-plugin/plugin.json` — added `"phase-explore"` keyword

## Test plan

- [ ] `docs/playbooks/phase-explore.md` mirrors `project-files/docs/playbooks/phase-explore.md` exactly
- [ ] `PHASE_NOTES_TEMPLATE.md` has `### Exploration` section with ownership comment
- [ ] `impl-brief.md` step 2 opens with the exploration check block
- [ ] All 3 wrappers point to the canonical playbook, not to each other
- [ ] `project-files/AGENTS.md` lists phase-explore in Workflow Playbooks and file ownership table
- [ ] Root `AGENTS.md` file map counts updated (10 playbooks, 9 skills)
- [ ] `plugin.json` keywords include `"phase-explore"`