### PR TITLE
chore: simplify pipeline — gotcha auto-capture, remove STATE change log, drop CONTEXT.md version

### DIFF
--- a/docs/playbooks/context-update.md
+++ b/docs/playbooks/context-update.md
@@ -11,7 +11,7 @@ This document is the single source of truth for the `context-update` workflow. R
 ## Required reads
 
 - `docs/PHASE_XX.md` — focus on the **Contracts** section
-- `docs/CONTEXT.md` — note `_meta.version`
+- `docs/CONTEXT.md` — current contracts (models, endpoints, schema, env vars)
 - `docs/STATE.md` — current phase statuses
 - `docs/CHANGELOG.md`
 
@@ -36,33 +36,29 @@ From the **Contracts** section, extract:
 
 If every Contracts subsection is `None`: no version bump needed. Skip to step 6 (STATE.md update).
 
-### 3. Determine version bump
+### 3. Determine if contracts changed
 
-- **No bump**: all subsections `None` (docs-only phase).
-- **Patch** (`v1.0` → `v1.1`): additive only — new tables, endpoints, types, or env vars; nothing removed or renamed.
-- **Minor** (`v1.1` → `v1.2`): breaking — renamed endpoints, removed fields, changed request/response shape, column type changes.
-
-State which bump applies and why before editing.
+- If every Contracts subsection is `None`: no contracts changed → skip steps 4 and 5; go directly
+  to step 6 (STATE.md update).
+- Otherwise: contracts changed → proceed with steps 4 and 5.
 
 ### 4. Update `docs/CONTEXT.md`
 
 Surgical edits:
 
-1. Increment `_meta.version` (if bump).
-2. Update `captured_at` to today (`YYYY-MM-DD`).
-3. Set `phase_completed` to the phase number (e.g. `"01"`).
-4. Set `phase_in_progress` to next phase number or `null`.
-5. **Append** to `core_models` — do NOT remove existing.
-6. **Append** to `endpoints_active` — do NOT remove existing.
-7. **Append** to `db_schema.tables`.
-8. Update `db_schema.current_head` to the latest alembic revision name (if backend-bearing).
-9. **Append** to `env_config.keys`.
-10. Update `notes`: one sentence, "Phase XX complete. [What was added]."
+1. Set `phase_completed` to the phase number (e.g. `"01"`).
+2. Set `phase_in_progress` to next phase number or `null`.
+3. **Append** to `core_models` — do NOT remove existing.
+4. **Append** to `endpoints_active` — do NOT remove existing.
+5. **Append** to `db_schema.tables`.
+6. Update `db_schema.current_head` to the latest alembic revision name (if backend-bearing).
+7. **Append** to `env_config.keys`.
+8. Update `notes`: one sentence, "Phase XX complete. [What was added]."
 
-### 5. Prepend to `docs/CHANGELOG.md` (only if version bumped)
+### 5. Prepend to `docs/CHANGELOG.md` (only if contracts changed)
 
 ```markdown
-## [new version] — [YYYY-MM-DD] — Phase [XX] complete
+## [YYYY-MM-DD] — Phase [XX] complete
 
 **Type**: phase-completion
 **Author**: AI (context-update)
@@ -75,27 +71,25 @@ Surgical edits:
 - None (additive change)
 
 ### Contract Updates
-- `CONTEXT.md` bumped from `vX.Y` to `vX.Z`
 - [new tables, endpoints, env vars]
 
 ### Notes
 [Notable decisions made during this phase.]
 ```
 
-If no version bump: no CHANGELOG entry.
+If no contracts changed: no CHANGELOG entry.
 
 ### 6. Update `docs/STATE.md`
 
 1. Change the `PHASE_[XX]` row status to `✅ done`.
 2. Change its Gate column from `⬜` to `✅`.
-3. Add a Change Log row: `| [YYYY-MM-DD] | PHASE_[XX] completed — CONTEXT.md bumped to vX.Z |` (or `— no bump` if applicable).
 
 ### 7. Report
 
 ```
 ## context-update complete — PHASE_[XX]
 
-CONTEXT.md:  bumped vX.Y → vX.Z / no bump — [reason]
+CONTEXT.md:  contracts appended / no change — [reason]
 STATE.md:    PHASE_[XX] marked ✅ done
 CHANGELOG.md: entry added / no entry needed
 
@@ -107,7 +101,6 @@ Next: /phase-init [XX+1] to scaffold the next phase.
 - Never remove existing entries from CONTEXT.md arrays — append only.
 - If the Contracts section is incomplete, stop and ask the architect to fill it in.
 - Do not commit.
-- `_meta.version` in CONTEXT.md is the source of truth; CHANGELOG entries derive from it.
 
 ## Done when
 

--- a/docs/playbooks/impl-assist.md
+++ b/docs/playbooks/impl-assist.md
@@ -88,6 +88,15 @@ After all target tasks are implemented:
 - Re-read the implemented files and confirm the contracts from `docs/PHASE_XX.md` are satisfied.
 - If any contract is unsatisfied, fix it before reporting success.
 
+### 6a. Record new gotchas (if any)
+
+If during implementation you encountered a non-obvious constraint, workaround, or failure mode
+that could affect future tasks or phases:
+
+- Add an entry to `docs/KNOWN_GOTCHAS.md` before writing the report.
+- Match the format of existing entries: Symptoms / Root cause / Fix / Agent protocol.
+- Skip this step if nothing novel was discovered — do not add redundant entries.
+
 ### 7. Report
 
 ```

--- a/docs/playbooks/phase-init.md
+++ b/docs/playbooks/phase-init.md
@@ -85,7 +85,6 @@ Copy `docs/PHASE_TEMPLATE.md` and substitute placeholders:
 | `[Phase Title]` | From SPEC.md §8 |
 | `v0.[XX].0` | Tag |
 | `PHASE_[XX-1]` | Previous phase |
-| `[VERSION]` | Current `_meta.version` from `docs/CONTEXT.md` |
 | Scope checkboxes | Items from §8 with task IDs assigned in step 4: `- [ ] \`B1\` [item] — _Depends on:_ —` |
 | Files | Explicit list from step 3 |
 | Contracts | Extracted sections from step 3 |
@@ -145,8 +144,6 @@ Contracts filled from SPEC.md:
 
 Before implementation, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
 Run /impl-brief [XX] (or /impl-brief [XX] [ID]) to generate concrete Implementation Plans.
-
-CONTEXT.md version at time of init: [version]
 ```
 
 ## Rules

--- a/docs/playbooks/spec-sync.md
+++ b/docs/playbooks/spec-sync.md
@@ -11,7 +11,7 @@ This document is the single source of truth for the `spec-sync` workflow. Runtim
 ## Required reads
 
 - `docs/SPEC.md` (updated)
-- `docs/CONTEXT.md` — note `_meta.version`
+- `docs/CONTEXT.md` — current contracts (models, endpoints, types, env vars)
 - `docs/STATE.md` — current phase statuses
 - `docs/CHANGELOG.md`
 - All `docs/PHASE_*.md` files
@@ -34,18 +34,19 @@ Identify which domains changed:
 
 For each changed domain, list affected phase files with precise reasons. **False-positive rule**: if unsure whether a phase is affected, mark it `⚠️ NEEDS_REVIEW`. A false positive is safer than a missed dependency.
 
-### 2. Determine version bump
+### 2. Determine if contracts changed
 
-- Additive contract change (new tables / endpoints / types / env vars): **patch bump** (`v1.1` → `v1.2`).
-- Breaking contract change (renamed, removed, retyped): **minor bump** (`v1.2` → `v2.0`).
-- No contract change (docs-only, non-functional only): **no bump** — use current version in the CHANGELOG entry heading.
+- **Contracts changed**: new / renamed / removed tables, endpoints, types, or env vars → proceed
+  with steps 3 and 4.
+- **No contract change** (docs-only, non-functional only): skip steps 3 and 4 and note "no
+  contract change" in the report.
 
-### 3. Prepend to `docs/CHANGELOG.md`
+### 3. Prepend to `docs/CHANGELOG.md` (only if contracts changed)
 
 Immediately after the `# CHANGELOG` heading and its intro lines, before any previous entry:
 
 ```markdown
-## [new or current CONTEXT version] — [YYYY-MM-DD] — [Short Title]
+## [YYYY-MM-DD] — [Short Title]
 
 **Type**: spec-change
 **Author**: AI (spec-sync)
@@ -59,7 +60,6 @@ Immediately after the `# CHANGELOG` heading and its intro lines, before any prev
 - (or: None — change has no impact on existing phases)
 
 ### Contract Updates
-- `CONTEXT.md` bumped from `vX.Y` to `vX.Z` (if applicable)
 - [renamed endpoints, new tables, etc.]
 - (or: No contract change — docs-only)
 
@@ -67,14 +67,12 @@ Immediately after the `# CHANGELOG` heading and its intro lines, before any prev
 [Any relevant trade-offs, decisions, or context.]
 ```
 
-### 4. Update `docs/CONTEXT.md` (only if contract changed)
+### 4. Update `docs/CONTEXT.md` (only if contracts changed)
 
-1. Increment `_meta.version` per step 2.
-2. Update `captured_at` to today (`YYYY-MM-DD`).
-3. Edit only the sections that changed: `core_models`, `endpoints_active`, `db_schema.tables`, `env_config.keys`.
-4. Update `notes` with one sentence about the spec change.
+1. Edit only the sections that changed: `core_models`, `endpoints_active`, `db_schema.tables`, `env_config.keys`.
+2. Update `notes` with one sentence about the spec change.
 
-If no contract change: leave CONTEXT.md untouched; note "no contract change" in the CHANGELOG entry.
+If no contract change: leave CONTEXT.md untouched.
 
 ### 5. Mark affected phases in `docs/STATE.md`
 
@@ -106,8 +104,8 @@ For each affected phase:
 ```
 ## spec-sync complete
 
-CHANGELOG.md: new entry added (v[old] → v[new] / no bump)
-CONTEXT.md:   [bumped to vX.Z / unchanged] — [reason]
+CHANGELOG.md: new entry added / no entry needed — [reason]
+CONTEXT.md:   contracts updated / unchanged — [reason]
 STATE.md:     phases marked ⚠️ NEEDS_REVIEW — [list / none]
 PHASE files patched: [list / none]
 Unaffected phases:   [list / none]

--- a/docs/playbooks/workflow-init.md
+++ b/docs/playbooks/workflow-init.md
@@ -155,7 +155,6 @@ If `docs/STACK.md` already existed, do **not** edit it. Print a clear message:
 
 ### 7. Stamp metadata
 
-- In `docs/STATE.md`, fill the `Change Log` table's first row date with today.
 - In `docs/CHANGELOG.md`, fill `[DATE]` and `[OWNER]` in the seed entry.
 - In `docs/CONTEXT.md`, fill `captured_at` with today's date.
 

--- a/project-files/AGENTS.md
+++ b/project-files/AGENTS.md
@@ -80,15 +80,6 @@ When `docs/SPEC.md` is modified:
 3. **Review** all changes before committing.
 4. **Do not implement** any phase marked `⚠️ NEEDS_REVIEW` until resolved.
 
-## CONTEXT.md Version Rules
-
-- **Format**: `vMAJOR.MINOR` (e.g. `v1.2`).
-- **Patch bump** (`v1.0` → `v1.1`): additive only — new endpoints, models, env vars.
-- **Minor bump** (`v1.1` → `v1.2`): breaking — renamed/removed endpoints, schema or type changes.
-- **No bump**: docs-only phase, zero contract changes.
-- Always update `captured_at` when the version changes.
-- `CONTEXT.md` is the Single Source of Truth for AI — never let it fall more than one phase behind.
-
 ## Workflow Playbooks
 
 The SDD workflows are defined in `docs/playbooks/`:

--- a/project-files/docs/playbooks/context-update.md
+++ b/project-files/docs/playbooks/context-update.md
@@ -11,7 +11,7 @@ This document is the single source of truth for the `context-update` workflow. R
 ## Required reads
 
 - `docs/PHASE_XX.md` — focus on the **Contracts** section
-- `docs/CONTEXT.md` — note `_meta.version`
+- `docs/CONTEXT.md` — current contracts (models, endpoints, schema, env vars)
 - `docs/STATE.md` — current phase statuses
 - `docs/CHANGELOG.md`
 
@@ -36,33 +36,29 @@ From the **Contracts** section, extract:
 
 If every Contracts subsection is `None`: no version bump needed. Skip to step 6 (STATE.md update).
 
-### 3. Determine version bump
+### 3. Determine if contracts changed
 
-- **No bump**: all subsections `None` (docs-only phase).
-- **Patch** (`v1.0` → `v1.1`): additive only — new tables, endpoints, types, or env vars; nothing removed or renamed.
-- **Minor** (`v1.1` → `v1.2`): breaking — renamed endpoints, removed fields, changed request/response shape, column type changes.
-
-State which bump applies and why before editing.
+- If every Contracts subsection is `None`: no contracts changed → skip steps 4 and 5; go directly
+  to step 6 (STATE.md update).
+- Otherwise: contracts changed → proceed with steps 4 and 5.
 
 ### 4. Update `docs/CONTEXT.md`
 
 Surgical edits:
 
-1. Increment `_meta.version` (if bump).
-2. Update `captured_at` to today (`YYYY-MM-DD`).
-3. Set `phase_completed` to the phase number (e.g. `"01"`).
-4. Set `phase_in_progress` to next phase number or `null`.
-5. **Append** to `core_models` — do NOT remove existing.
-6. **Append** to `endpoints_active` — do NOT remove existing.
-7. **Append** to `db_schema.tables`.
-8. Update `db_schema.current_head` to the latest alembic revision name (if backend-bearing).
-9. **Append** to `env_config.keys`.
-10. Update `notes`: one sentence, "Phase XX complete. [What was added]."
+1. Set `phase_completed` to the phase number (e.g. `"01"`).
+2. Set `phase_in_progress` to next phase number or `null`.
+3. **Append** to `core_models` — do NOT remove existing.
+4. **Append** to `endpoints_active` — do NOT remove existing.
+5. **Append** to `db_schema.tables`.
+6. Update `db_schema.current_head` to the latest alembic revision name (if backend-bearing).
+7. **Append** to `env_config.keys`.
+8. Update `notes`: one sentence, "Phase XX complete. [What was added]."
 
-### 5. Prepend to `docs/CHANGELOG.md` (only if version bumped)
+### 5. Prepend to `docs/CHANGELOG.md` (only if contracts changed)
 
 ```markdown
-## [new version] — [YYYY-MM-DD] — Phase [XX] complete
+## [YYYY-MM-DD] — Phase [XX] complete
 
 **Type**: phase-completion
 **Author**: AI (context-update)
@@ -75,27 +71,25 @@ Surgical edits:
 - None (additive change)
 
 ### Contract Updates
-- `CONTEXT.md` bumped from `vX.Y` to `vX.Z`
 - [new tables, endpoints, env vars]
 
 ### Notes
 [Notable decisions made during this phase.]
 ```
 
-If no version bump: no CHANGELOG entry.
+If no contracts changed: no CHANGELOG entry.
 
 ### 6. Update `docs/STATE.md`
 
 1. Change the `PHASE_[XX]` row status to `✅ done`.
 2. Change its Gate column from `⬜` to `✅`.
-3. Add a Change Log row: `| [YYYY-MM-DD] | PHASE_[XX] completed — CONTEXT.md bumped to vX.Z |` (or `— no bump` if applicable).
 
 ### 7. Report
 
 ```
 ## context-update complete — PHASE_[XX]
 
-CONTEXT.md:  bumped vX.Y → vX.Z / no bump — [reason]
+CONTEXT.md:  contracts appended / no change — [reason]
 STATE.md:    PHASE_[XX] marked ✅ done
 CHANGELOG.md: entry added / no entry needed
 
@@ -107,7 +101,6 @@ Next: /phase-init [XX+1] to scaffold the next phase.
 - Never remove existing entries from CONTEXT.md arrays — append only.
 - If the Contracts section is incomplete, stop and ask the architect to fill it in.
 - Do not commit.
-- `_meta.version` in CONTEXT.md is the source of truth; CHANGELOG entries derive from it.
 
 ## Done when
 

--- a/project-files/docs/playbooks/impl-assist.md
+++ b/project-files/docs/playbooks/impl-assist.md
@@ -88,6 +88,15 @@ After all target tasks are implemented:
 - Re-read the implemented files and confirm the contracts from `docs/PHASE_XX.md` are satisfied.
 - If any contract is unsatisfied, fix it before reporting success.
 
+### 6a. Record new gotchas (if any)
+
+If during implementation you encountered a non-obvious constraint, workaround, or failure mode
+that could affect future tasks or phases:
+
+- Add an entry to `docs/KNOWN_GOTCHAS.md` before writing the report.
+- Match the format of existing entries: Symptoms / Root cause / Fix / Agent protocol.
+- Skip this step if nothing novel was discovered — do not add redundant entries.
+
 ### 7. Report
 
 ```

--- a/project-files/docs/playbooks/phase-init.md
+++ b/project-files/docs/playbooks/phase-init.md
@@ -85,7 +85,6 @@ Copy `docs/PHASE_TEMPLATE.md` and substitute placeholders:
 | `[Phase Title]` | From SPEC.md §8 |
 | `v0.[XX].0` | Tag |
 | `PHASE_[XX-1]` | Previous phase |
-| `[VERSION]` | Current `_meta.version` from `docs/CONTEXT.md` |
 | Scope checkboxes | Items from §8 with task IDs assigned in step 4: `- [ ] \`B1\` [item] — _Depends on:_ —` |
 | Files | Explicit list from step 3 |
 | Contracts | Extracted sections from step 3 |
@@ -145,8 +144,6 @@ Contracts filled from SPEC.md:
 
 Before implementation, verify any remaining [TODO: verify] markers and the Gate Checks smoke-test expected response.
 Run /impl-brief [XX] (or /impl-brief [XX] [ID]) to generate concrete Implementation Plans.
-
-CONTEXT.md version at time of init: [version]
 ```
 
 ## Rules

--- a/project-files/docs/playbooks/spec-sync.md
+++ b/project-files/docs/playbooks/spec-sync.md
@@ -11,7 +11,7 @@ This document is the single source of truth for the `spec-sync` workflow. Runtim
 ## Required reads
 
 - `docs/SPEC.md` (updated)
-- `docs/CONTEXT.md` — note `_meta.version`
+- `docs/CONTEXT.md` — current contracts (models, endpoints, types, env vars)
 - `docs/STATE.md` — current phase statuses
 - `docs/CHANGELOG.md`
 - All `docs/PHASE_*.md` files
@@ -34,18 +34,19 @@ Identify which domains changed:
 
 For each changed domain, list affected phase files with precise reasons. **False-positive rule**: if unsure whether a phase is affected, mark it `⚠️ NEEDS_REVIEW`. A false positive is safer than a missed dependency.
 
-### 2. Determine version bump
+### 2. Determine if contracts changed
 
-- Additive contract change (new tables / endpoints / types / env vars): **patch bump** (`v1.1` → `v1.2`).
-- Breaking contract change (renamed, removed, retyped): **minor bump** (`v1.2` → `v2.0`).
-- No contract change (docs-only, non-functional only): **no bump** — use current version in the CHANGELOG entry heading.
+- **Contracts changed**: new / renamed / removed tables, endpoints, types, or env vars → proceed
+  with steps 3 and 4.
+- **No contract change** (docs-only, non-functional only): skip steps 3 and 4 and note "no
+  contract change" in the report.
 
-### 3. Prepend to `docs/CHANGELOG.md`
+### 3. Prepend to `docs/CHANGELOG.md` (only if contracts changed)
 
 Immediately after the `# CHANGELOG` heading and its intro lines, before any previous entry:
 
 ```markdown
-## [new or current CONTEXT version] — [YYYY-MM-DD] — [Short Title]
+## [YYYY-MM-DD] — [Short Title]
 
 **Type**: spec-change
 **Author**: AI (spec-sync)
@@ -59,7 +60,6 @@ Immediately after the `# CHANGELOG` heading and its intro lines, before any prev
 - (or: None — change has no impact on existing phases)
 
 ### Contract Updates
-- `CONTEXT.md` bumped from `vX.Y` to `vX.Z` (if applicable)
 - [renamed endpoints, new tables, etc.]
 - (or: No contract change — docs-only)
 
@@ -67,14 +67,12 @@ Immediately after the `# CHANGELOG` heading and its intro lines, before any prev
 [Any relevant trade-offs, decisions, or context.]
 ```
 
-### 4. Update `docs/CONTEXT.md` (only if contract changed)
+### 4. Update `docs/CONTEXT.md` (only if contracts changed)
 
-1. Increment `_meta.version` per step 2.
-2. Update `captured_at` to today (`YYYY-MM-DD`).
-3. Edit only the sections that changed: `core_models`, `endpoints_active`, `db_schema.tables`, `env_config.keys`.
-4. Update `notes` with one sentence about the spec change.
+1. Edit only the sections that changed: `core_models`, `endpoints_active`, `db_schema.tables`, `env_config.keys`.
+2. Update `notes` with one sentence about the spec change.
 
-If no contract change: leave CONTEXT.md untouched; note "no contract change" in the CHANGELOG entry.
+If no contract change: leave CONTEXT.md untouched.
 
 ### 5. Mark affected phases in `docs/STATE.md`
 
@@ -106,8 +104,8 @@ For each affected phase:
 ```
 ## spec-sync complete
 
-CHANGELOG.md: new entry added (v[old] → v[new] / no bump)
-CONTEXT.md:   [bumped to vX.Z / unchanged] — [reason]
+CHANGELOG.md: new entry added / no entry needed — [reason]
+CONTEXT.md:   contracts updated / unchanged — [reason]
 STATE.md:     phases marked ⚠️ NEEDS_REVIEW — [list / none]
 PHASE files patched: [list / none]
 Unaffected phases:   [list / none]

--- a/project-files/docs/playbooks/workflow-init.md
+++ b/project-files/docs/playbooks/workflow-init.md
@@ -155,7 +155,6 @@ If `docs/STACK.md` already existed, do **not** edit it. Print a clear message:
 
 ### 7. Stamp metadata
 
-- In `docs/STATE.md`, fill the `Change Log` table's first row date with today.
 - In `docs/CHANGELOG.md`, fill `[DATE]` and `[OWNER]` in the seed entry.
 - In `docs/CONTEXT.md`, fill `captured_at` with today's date.
 

--- a/project-files/docs/templates/CONTEXT.md
+++ b/project-files/docs/templates/CONTEXT.md
@@ -1,9 +1,7 @@
 {
   "_meta": {
-    "version": "v1.0",
     "format": "SDD CONTEXT.md — Single Source of Truth for AI agent",
-    "update_rule": "Bump version on schema/API/type changes. Use /context-update skill after each phase.",
-    "version_scheme": "patch (v1.0→v1.1) = additive only; minor (v1.1→v1.2) = breaking change"
+    "update_rule": "Append contracts after each phase via /context-update. Never remove existing entries."
   },
 
   "captured_at": "[DATE]",

--- a/project-files/docs/templates/PHASE_TEMPLATE.md
+++ b/project-files/docs/templates/PHASE_TEMPLATE.md
@@ -11,7 +11,6 @@
 | Status | `⏳ pending` |
 | Tag | `v0.[XX].0` |
 | Depends on | PHASE_[XX-1] gate passing |
-| CONTEXT.md version | `[VERSION — snapshot at time of writing, e.g. v1.1]` |
 
 ---
 
@@ -154,6 +153,6 @@ feat(phase-[XX]): [short description — what was built, not how]
 - [ ] All architect review notes resolved
 - [ ] `docs/CONTEXT.md` updated — run `/context-update [XX]`
 - [ ] `docs/STATE.md` phase row updated to `✅ done`
-- [ ] `docs/CHANGELOG.md` entry added (if CONTEXT.md version bumped)
+- [ ] `docs/CHANGELOG.md` entry added (if contracts changed)
 - [ ] Committed atomically on `feat/phase-[XX]` branch
 - [ ] Tag created after merge to develop: `git tag -a v0.[XX].0 -m "Phase [XX]: [title]"`

--- a/project-files/docs/templates/STATE.md
+++ b/project-files/docs/templates/STATE.md
@@ -44,4 +44,3 @@ None
 ## Rollback Notes
 
 <!-- Document here if a phase was rolled back or a migration reversed. -->
-

--- a/project-files/docs/templates/STATE.md
+++ b/project-files/docs/templates/STATE.md
@@ -45,12 +45,3 @@ None
 
 <!-- Document here if a phase was rolled back or a migration reversed. -->
 
----
-
-## Change Log
-
-| Date   | Event |
-|--------|-------|
-| [DATE] | Project initialized with SDD workflow |
-
-<!-- Add entries: [date]: PHASE_N completed / spec changed / blocker resolved -->


### PR DESCRIPTION
## Summary

Three incremental improvements to the sdd-workflow pipeline, all reductions in surface area:

- **KNOWN_GOTCHAS auto-capture** — `impl-assist` now has a step 6a that prompts the agent to record non-obvious constraints/workarounds discovered during implementation into `KNOWN_GOTCHAS.md` before writing the report. Converts a human-memory obligation into an agent-assisted habit.

- **STATE.md Change Log removed** — The `## Change Log` section in `STATE.md` was confirmed to be write-only (0 reads across all playbooks) and duplicated `docs/CHANGELOG.md`. Removed from the template, from `context-update` step 6, and from `workflow-init` stamp step. `STATE.md` is now a pure live status board.

- **CONTEXT.md version system removed** — The `_meta.version` / patch/minor bump rules were purely cosmetic (no playbook ever used the version value for conditional logic). The real gate was always "did contracts change?" Simplified to a binary check. Removed: version fields from `CONTEXT.md` template, `[VERSION]` snapshot row from `PHASE_TEMPLATE`, `CONTEXT.md Version Rules` section from `AGENTS.md`, version bump logic from `spec-sync`.

## Files changed (14)

- `docs/playbooks/impl-assist.md` + mirror
- `docs/playbooks/context-update.md` + mirror
- `docs/playbooks/spec-sync.md` + mirror
- `docs/playbooks/phase-init.md` + mirror
- `docs/playbooks/workflow-init.md` + mirror
- `project-files/docs/templates/STATE.md`
- `project-files/docs/templates/CONTEXT.md`
- `project-files/docs/templates/PHASE_TEMPLATE.md`
- `project-files/AGENTS.md`

## Test plan

- [ ] `impl-assist.md` has step 6a between steps 6 and 7
- [ ] `STATE.md` template has no `## Change Log` section
- [ ] `context-update.md` step 6 has exactly 2 sub-steps
- [ ] `context-update.md` step 3 is "contracts changed?" binary (no patch/minor)
- [ ] `context-update.md` step 4 has no `_meta.version` or `captured_at` sub-steps
- [ ] `spec-sync.md` has no version bump logic
- [ ] `phase-init.md` placeholder table has no `[VERSION]` row
- [ ] `CONTEXT.md` template `_meta` has no `version` field
- [ ] `PHASE_TEMPLATE.md` has no `CONTEXT.md version` row
- [ ] `AGENTS.md` has no `CONTEXT.md Version Rules` section
- [ ] All 5 playbooks mirrored to `project-files/docs/playbooks/`