### PR TITLE
docs: clarify skill loading and add bootstrap prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,40 @@ It defines a documentation contract, a repeatable phase loop, and clear gate cri
 
 ## Getting started
 
+### 1. Clone the workflow bundle
+
 ```bash
 git clone https://github.com/avatarsik6699/sdd-workflow.git /tmp/sdd-workflow
-cd /tmp/sdd-workflow
-# Run in your agent session:
-/workflow-init /path/to/your-project
+```
+
+### 2. Bootstrap into your project
+
+Open an AI agent session with `/tmp/sdd-workflow` as the working directory, then pick one option:
+
+**Option A — slash command** (Claude Code CLI or Codex with the plugin loaded)
+
+```
+/workflow-init /absolute/path/to/your-project
+```
+
+**Option B — bootstrap prompt** (any AI: claude.ai chat, Cursor, Copilot, etc.)
+
+Paste the following into the chat:
+
+```
+Read docs/playbooks/workflow-init.md and execute the workflow-init procedure.
+Target project path: /absolute/path/to/your-project
+```
+
+> **Why two options?** `/workflow-init` is a slash command that auto-loads only when the agent
+> runtime reads `.claude/skills/workflow-init/SKILL.md` at session start — this happens reliably
+> in Claude Code CLI but may not happen in chat interfaces or other tools. The bootstrap prompt
+> reads the same canonical playbook directly and produces the same result without relying on
+> skill registration.
+
+### 3. Enter your target project and run the delivery loop
+
+```bash
 cd /path/to/your-project
 ```
 
@@ -69,6 +98,12 @@ This structure keeps scope controlled and gives contributors a consistent way to
 - [.claude/skills/workflow-init/](.claude/skills/workflow-init/) — bootstrap wrapper for this repo.
 - [plugins/sdd-workflow/](plugins/sdd-workflow/) — bootstrap plugin for Codex.
 - [AGENTS.md](AGENTS.md) — rules for working on this repository.
+
+> **Note on visible skills:** from this repository only `/workflow-init` is registered as a
+> slash command. The 9 workflow skills (`/spec-init`, `/phase-init`, `/phase-explore`, etc.)
+> live in `project-files/.claude/skills/` — they are templates copied into target projects by
+> `/workflow-init`, and become available only when an agent session is opened inside that target
+> project.
 
 ## License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -15,11 +15,40 @@
 
 ## Начало работы
 
+### 1. Клонировать bundle workflow
+
 ```bash
 git clone https://github.com/avatarsik6699/sdd-workflow.git /tmp/sdd-workflow
-cd /tmp/sdd-workflow
-# Запускать в сессии агента:
-/workflow-init /path/to/your-project
+```
+
+### 2. Запустить bootstrap в целевой проект
+
+Откройте сессию агента с рабочей директорией `/tmp/sdd-workflow` и выберите один из вариантов:
+
+**Вариант А — slash-команда** (Claude Code CLI или Codex с загруженным плагином)
+
+```
+/workflow-init /absolute/path/to/your-project
+```
+
+**Вариант Б — bootstrap-промпт** (любой ИИ: claude.ai, Cursor, Copilot и т.д.)
+
+Вставьте в чат следующий текст:
+
+```
+Read docs/playbooks/workflow-init.md and execute the workflow-init procedure.
+Target project path: /absolute/path/to/your-project
+```
+
+> **Почему два варианта?** `/workflow-init` — это slash-команда, которая загружается
+> автоматически только когда агент читает `.claude/skills/workflow-init/SKILL.md` при старте
+> сессии. В Claude Code CLI это происходит надёжно, но в чат-интерфейсах и других инструментах —
+> нет. Bootstrap-промпт читает тот же канонический playbook напрямую и даёт тот же результат
+> без зависимости от регистрации skill.
+
+### 3. Перейти в целевой проект и запустить цикл поставки
+
+```bash
 cd /path/to/your-project
 ```
 
@@ -69,6 +98,12 @@ cd /path/to/your-project
 - [.claude/skills/workflow-init/](.claude/skills/workflow-init/) — bootstrap-обёртка для этого репозитория.
 - [plugins/sdd-workflow/](plugins/sdd-workflow/) — bootstrap-плагин для Codex.
 - [AGENTS.md](AGENTS.md) — правила работы с этим репозиторием.
+
+> **Примечание о видимых skills:** из этого репозитория зарегистрирована только команда
+> `/workflow-init`. Остальные 9 skills (`/spec-init`, `/phase-init`, `/phase-explore` и т.д.)
+> находятся в `project-files/.claude/skills/` — это шаблоны, которые `/workflow-init` копирует
+> в целевой проект. Они становятся доступны только после открытия сессии агента внутри целевого
+> проекта.
 
 ## Лицензия
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,30 @@
 # FAQ
 
+## I see many skill files in the repo but only `/workflow-init` shows up as a command — why?
+
+The 9 workflow skills (`/spec-init`, `/phase-init`, `/phase-explore`, etc.) live in
+`project-files/.claude/skills/`. That directory is a template tree, not an active skills
+directory — its contents are copied into a target project by `/workflow-init`. Once installed,
+open an agent session inside your target project and all 9 skills will be available there.
+
+From the `sdd-workflow` repo itself, only `.claude/skills/workflow-init/SKILL.md` is registered,
+so only `/workflow-init` loads.
+
+## The `/workflow-init` slash command doesn't appear in my AI interface — what do I do?
+
+Slash commands auto-load only when the agent runtime reads `SKILL.md` files at session start.
+This happens reliably in Claude Code CLI but may not happen in chat interfaces (claude.ai,
+Cursor, Copilot, etc.).
+
+Use the bootstrap prompt instead. With `/tmp/sdd-workflow` as your working directory, paste:
+
+```
+Read docs/playbooks/workflow-init.md and execute the workflow-init procedure.
+Target project path: /absolute/path/to/your-project
+```
+
+This reads the canonical playbook directly and produces the same result.
+
 ## Is this tied to one stack?
 
 No. The workflow is stack-agnostic and ships only markdown docs, wrappers, and shell hooks.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,9 +4,26 @@
 
 ```bash
 git clone https://github.com/avatarsik6699/sdd-workflow.git /tmp/sdd-workflow
-cd /tmp/sdd-workflow
-/workflow-init /path/to/target-project
 ```
+
+Open an AI agent session with `/tmp/sdd-workflow` as the working directory, then choose one of these options:
+
+**Option A — slash command** (Claude Code CLI or Codex with the plugin loaded)
+
+```
+/workflow-init /absolute/path/to/target-project
+```
+
+**Option B — bootstrap prompt** (any AI: claude.ai chat, Cursor, Copilot, etc.)
+
+```
+Read docs/playbooks/workflow-init.md and execute the workflow-init procedure.
+Target project path: /absolute/path/to/target-project
+```
+
+> The `/workflow-init` slash command auto-loads only when the agent runtime reads
+> `.claude/skills/workflow-init/SKILL.md` at session start. The bootstrap prompt achieves the
+> same result in any AI that has filesystem access to the cloned repo.
 
 ## 2. Enter your target project
 
@@ -22,7 +39,7 @@ cd /path/to/target-project
 2. `/phase-init 01` — scaffold `docs/PHASE_01.md` + `docs/PHASE_01_NOTES.md` with task IDs
 3. **Implement the scope** (see implementation paths below)
 4. `/phase-gate 01` — validate automated checks + architect review notes
-5. `/context-update 01` — mark phase done, bump CONTEXT.md version
+5. `/context-update 01` — mark phase done, sync CONTEXT.md and CHANGELOG.md
 
 ### Optional: before-implementation planning
 


### PR DESCRIPTION
## Summary

- Restructures "Getting started" in README.md and README.ru.md: two clear options — slash command (Claude Code CLI / Codex) and a copy-pasteable bootstrap prompt that works in any AI interface without skill registration
- Adds a "Repo map" note explaining that only `/workflow-init` is registered from the sdd-workflow repo itself; the 9 workflow skills live in `project-files/.claude/skills/` (templates) and only become active after being copied to a target project by `workflow-init`
- Adds two FAQ entries: "why don't I see all the skills?" and "what if `/workflow-init` doesn't auto-load?"
- Fixes stale "bump CONTEXT.md version" text in `docs/quickstart.md` (version bump was removed in #22)

## Why

Skill auto-loading only happens when the agent runtime reads `SKILL.md` at session start — reliably in Claude Code CLI, but not in chat interfaces (claude.ai, Cursor, Copilot). The old README implied `/workflow-init` would "just work" with no fallback, which caused confusion.

## Test plan

- [ ] Read README.md getting started section — both options clearly described
- [ ] Read README.ru.md — mirrors EN changes in Russian
- [ ] Read docs/faq.md — two new Q&As present
- [ ] Read docs/quickstart.md — bootstrap prompt shown, no "bump CONTEXT.md version" text